### PR TITLE
feat: add pagination to /invest assets command

### DIFF
--- a/src/commands/invest.test.ts
+++ b/src/commands/invest.test.ts
@@ -1,7 +1,114 @@
 import { describe, expect, it } from "bun:test";
-import { chunkSymbols } from "./invest";
+import { chunkSymbols, paginateItems } from "./invest";
 
 describe("invest command utilities", () => {
+	describe("paginateItems", () => {
+		it("returns first page of items", () => {
+			const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+			const result = paginateItems(items, 1, 3);
+
+			expect(result.pageItems).toEqual([1, 2, 3]);
+			expect(result.currentPage).toBe(1);
+			expect(result.totalPages).toBe(4);
+			expect(result.totalItems).toBe(10);
+			expect(result.startIndex).toBe(0);
+			expect(result.endIndex).toBe(3);
+		});
+
+		it("returns middle page of items", () => {
+			const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+			const result = paginateItems(items, 2, 3);
+
+			expect(result.pageItems).toEqual([4, 5, 6]);
+			expect(result.currentPage).toBe(2);
+			expect(result.totalPages).toBe(4);
+			expect(result.startIndex).toBe(3);
+			expect(result.endIndex).toBe(6);
+		});
+
+		it("returns last page with fewer items", () => {
+			const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+			const result = paginateItems(items, 4, 3);
+
+			expect(result.pageItems).toEqual([10]);
+			expect(result.currentPage).toBe(4);
+			expect(result.totalPages).toBe(4);
+			expect(result.startIndex).toBe(9);
+			expect(result.endIndex).toBe(10);
+		});
+
+		it("clamps page number to max when too high", () => {
+			const items = [1, 2, 3, 4, 5];
+			const result = paginateItems(items, 100, 2);
+
+			expect(result.pageItems).toEqual([5]);
+			expect(result.currentPage).toBe(3);
+			expect(result.totalPages).toBe(3);
+		});
+
+		it("clamps page number to 1 when zero or negative", () => {
+			const items = [1, 2, 3, 4, 5];
+			const result = paginateItems(items, 0, 2);
+
+			expect(result.pageItems).toEqual([1, 2]);
+			expect(result.currentPage).toBe(1);
+
+			const resultNegative = paginateItems(items, -5, 2);
+			expect(resultNegative.currentPage).toBe(1);
+		});
+
+		it("handles empty array", () => {
+			const items: number[] = [];
+			const result = paginateItems(items, 1, 10);
+
+			expect(result.pageItems).toEqual([]);
+			expect(result.currentPage).toBe(1);
+			expect(result.totalPages).toBe(1);
+			expect(result.totalItems).toBe(0);
+		});
+
+		it("handles exact page fit", () => {
+			const items = [1, 2, 3, 4, 5, 6];
+			const result = paginateItems(items, 2, 3);
+
+			expect(result.pageItems).toEqual([4, 5, 6]);
+			expect(result.currentPage).toBe(2);
+			expect(result.totalPages).toBe(2);
+		});
+
+		it("handles single item", () => {
+			const items = ["only"];
+			const result = paginateItems(items, 1, 10);
+
+			expect(result.pageItems).toEqual(["only"]);
+			expect(result.totalPages).toBe(1);
+		});
+
+		it("works with 15 items per page (assets scenario)", () => {
+			const items = Array.from({ length: 47 }, (_, i) => `ASSET${i}`);
+
+			const page1 = paginateItems(items, 1, 15);
+			expect(page1.pageItems).toHaveLength(15);
+			expect(page1.totalPages).toBe(4);
+			expect(page1.pageItems[0]).toBe("ASSET0");
+
+			const page2 = paginateItems(items, 2, 15);
+			expect(page2.pageItems).toHaveLength(15);
+			expect(page2.pageItems[0]).toBe("ASSET15");
+
+			const page4 = paginateItems(items, 4, 15);
+			expect(page4.pageItems).toHaveLength(2);
+			expect(page4.pageItems[0]).toBe("ASSET45");
+		});
+
+		it("preserves item types", () => {
+			const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+			const result = paginateItems(items, 1, 2);
+
+			expect(result.pageItems).toEqual([{ id: 1 }, { id: 2 }]);
+		});
+	});
+
 	describe("chunkSymbols", () => {
 		it("returns single chunk when symbols fit in limit", () => {
 			const symbols = ["AAPL", "MSFT", "GOOGL"];

--- a/src/commands/invest.ts
+++ b/src/commands/invest.ts
@@ -144,6 +144,14 @@ export const data = new ChatInputCommandBuilder()
 					.setNameLocalizations({ cs: "kompaktní" })
 					.setDescription("Show only symbols in compact format")
 					.setDescriptionLocalizations({ cs: "Zobrazit pouze symboly v kompaktním formátu" }),
+			)
+			.addIntegerOptions((option) =>
+				option
+					.setName("page")
+					.setNameLocalizations({ cs: "stránka" })
+					.setDescription("Page number (15 assets per page)")
+					.setDescriptionLocalizations({ cs: "Číslo stránky (15 aktiv na stránku)" })
+					.setMinValue(1),
 			),
 	)
 	// Info subcommand
@@ -571,8 +579,10 @@ async function handleAssets(
 	const assetType = (interaction.options.getString("type") || "all") as "stock_us" | "stock_intl" | "crypto" | "all";
 	const search = interaction.options.getString("search");
 	const compact = interaction.options.getBoolean("compact") ?? false;
+	const page = interaction.options.getInteger("page") ?? 1;
+	const ASSETS_PER_PAGE = 15;
 
-	// Fetch assets - if compact mode, fetch all assets using pagination
+	// Fetch assets - if compact mode or page specified, fetch all assets using pagination
 	type AssetWithPrice = {
 		asset: {
 			id: number;
@@ -597,38 +607,16 @@ async function handleAssets(
 	};
 	let allAssets: AssetWithPrice[] = [];
 
-	if (compact) {
-		// Fetch ALL assets using pagination
-		let offset = 0;
-		const limit = 100; // Max limit per API request
-		let hasMore = true;
+	// Fetch ALL assets using pagination (needed for compact mode, page navigation, and search)
+	let offset = 0;
+	const limit = 100; // Max limit per API request
+	let hasMore = true;
 
-		while (hasMore) {
-			const [error, result] = await orpc.users.investments.assets({
-				assetType,
-				limit,
-				offset,
-			});
-
-			if (error) {
-				console.error("Error fetching assets:", error);
-				const errorEmbed = createErrorEmbed("Chyba", "Nepodařilo se načíst aktiva.");
-				await interaction.editReply({ embeds: [errorEmbed] });
-				return;
-			}
-
-			allAssets.push(...result.assets);
-
-			// Check if there are more assets to fetch
-			hasMore = result.assets.length === limit;
-			offset += limit;
-		}
-	} else {
-		// Regular mode: fetch limited assets
+	while (hasMore) {
 		const [error, result] = await orpc.users.investments.assets({
 			assetType,
-			limit: 25,
-			offset: 0,
+			limit,
+			offset,
 		});
 
 		if (error) {
@@ -638,7 +626,11 @@ async function handleAssets(
 			return;
 		}
 
-		allAssets = result.assets;
+		allAssets.push(...result.assets);
+
+		// Check if there are more assets to fetch
+		hasMore = result.assets.length === limit;
+		offset += limit;
 	}
 
 	// Filter by search if provided (search in symbol, name, and description)
@@ -698,9 +690,26 @@ async function handleAssets(
 			await interaction.followUp({ embeds: [followUpEmbed] });
 		}
 	} else {
-		// Regular detailed view (existing behavior)
-		const assetList = allAssets
-			.slice(0, 15)
+		// Regular detailed view with pagination
+		const totalAssets = allAssets.length;
+		const totalPages = Math.ceil(totalAssets / ASSETS_PER_PAGE);
+		const currentPage = Math.min(page, totalPages);
+		const startIndex = (currentPage - 1) * ASSETS_PER_PAGE;
+		const endIndex = startIndex + ASSETS_PER_PAGE;
+
+		const pageAssets = allAssets.slice(startIndex, endIndex);
+
+		if (pageAssets.length === 0) {
+			const embed = createInvestmentEmbed(typeLabel)
+				.setDescription(`**Stránka ${page} neexistuje**\n\nCelkem je k dispozici ${totalPages} ${totalPages === 1 ? "stránka" : totalPages < 5 ? "stránky" : "stránek"}.`)
+				.setFooter(createInvestmentHelpFooter())
+				.setTimestamp();
+
+			await interaction.editReply({ embeds: [embed] });
+			return;
+		}
+
+		const assetList = pageAssets
 			.map((item: AssetWithPrice) => {
 				const price = item.currentPrice ? formatPrice(item.currentPrice) : "N/A";
 				const change = item.changePercent24h !== null ? formatPercentageChange(item.changePercent24h) : "";
@@ -710,9 +719,13 @@ async function handleAssets(
 			})
 			.join("\n\n");
 
+		const pageInfo = totalPages > 1
+			? `Stránka ${currentPage}/${totalPages} (celkem ${totalAssets} aktiv)`
+			: `Zobrazeno ${totalAssets} aktiv`;
+
 		const embed = createInvestmentEmbed(typeLabel)
 			.setDescription(assetList)
-			.setFooter(createInvestmentHelpFooter(`Zobrazeno ${Math.min(allAssets.length, 15)} aktiv`))
+			.setFooter(createInvestmentHelpFooter(pageInfo))
 			.setTimestamp();
 
 		await interaction.editReply({ embeds: [embed] });


### PR DESCRIPTION
Add a `page` option to the assets subcommand allowing users to navigate through all available assets (15 per page) instead of being limited to the first 15.