### PR TITLE
fix: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/evobug-com/bot/security/code-scanning/1](https://github.com/evobug-com/bot/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` key to the workflow to explicitly declare the minimal required privileges for the GITHUB_TOKEN. Since this workflow only checks out code and performs CI tasks (build, lint, test) and does not update PRs, create issues, etc., it only needs read access to repository contents. Therefore, add `permissions: contents: read` at the workflow root (just below the `name:` line and before `on:`), so it applies to all contained jobs. No other changes or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
