### PR TITLE
feat(admin-ai): conversation memory, 5 new tools, audit-log query (v2.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ Formát je založen na [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- commits after XXX -->
 
 
+## [2.8.4] - 2026-05-03
+
+### Přidáno
+- Admin AI: paměť konverzace přes Discord reply chain — když admin odpoví na botovu zprávu, bot rekonstruuje historii (až 10 zpráv) a má kontext pro upřesňující dotazy
+- Admin AI: nový nástroj `clone_channel` — zkopíruje typ, topic, slowmode, NSFW i per-channel oprávnění ze zdrojového kanálu (řeší "vytvoř kanál podle stávajících sourozenců")
+- Admin AI: nový nástroj `delete_channel` — destruktivní mazání kanálu s explicitním varováním v náhledu
+- Admin AI: nový nástroj `create_category` — vytvoření nové kategorie
+- Admin AI: nové nástroje `assign_role` a `remove_role` — přiřazení/odebrání role členovi
+- Admin AI: nový read-only nástroj `query_audit_log` — bot umí odpovídat na otázky typu "kdo smazal #foo" nebo "kdo banoval @user" čtením Discord audit logu (filtry: typ akce, cíl, vykonavatel, limit)
+- Admin AI: vícekrokový tool loop (max 5 iterací) — bot může nejprve zavolat info nástroj, dostat výsledek a pak teprve naplánovat akce; info nástroje běží okamžitě bez potvrzování, akce stále vyžadují kliknutí Potvrdit
+
+### Změněno
+- Admin AI: přidáno striktní pravidlo pro vyjasnění — pokud zpráva obsahuje token, který nelze jednoznačně přiřadit ke kanálu/kategorii/roli, bot se nejprve zeptá místo hádání
+- Admin AI: prompt explicitně říká, že nové kanály dědí oprávnění kategorie (per-channel overrides nelze kopírovat) a kdy použít `clone_channel` vs `create_channel`, požadavky na identifikaci členů u rolí, a oddělení info/akce volání do samostatných tahů
+
+### Opraveno
+- Admin AI používalo neplatné model ID `anthropic/claude-sonnet-4-20250514` (OpenRouter vracel 400) — přepnuto na alias `anthropic/claude-sonnet-latest`, který automaticky ukazuje na nejnovější Sonnet
+- Admin AI: tlačítka Potvrdit/Zrušit padala při odeslání kvůli chybě v `@discordjs/builders` v2 prerelease (validátor odmítal jednoznakové unicode emoji v `setEmoji`); emoji přesunuto do textu tlačítka
+
+
 ## [2.8.2] - 2026-03-30
 
 ### Přidáno

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "allcom-bot",
-	"version": "2.8.2",
+	"version": "2.8.4",
 	"description": "Allcom Discord bot with modular architecture",
 	"private": true,
 	"type": "module",

--- a/src/handlers/handleAdminAI.ts
+++ b/src/handlers/handleAdminAI.ts
@@ -5,15 +5,18 @@ import { openrouter } from "../utils/openrouter.ts";
 import { createLogger } from "../util/logger.ts";
 import { gatherGuildContext } from "../services/adminAI/guildContext.ts";
 import { buildSystemPrompt } from "../services/adminAI/prompt.ts";
-import { adminToolDefinitions, executeToolCall, generateActionSummary } from "../services/adminAI/tools.ts";
+import { adminToolDefinitions, executeInfoTool, executeToolCall, generateActionSummary, INFO_TOOLS } from "../services/adminAI/tools.ts";
 import { buildCancelledEmbed, buildConfirmButtons, buildPreviewEmbed, buildResultEmbed } from "../services/adminAI/actionPreview.ts";
+import { gatherConversationHistory } from "../services/adminAI/conversationHistory.ts";
 import type { ActionResult, PendingAdminAction, PlannedAction } from "../services/adminAI/types.ts";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
 const log = createLogger("AdminAI");
 
-const ADMIN_AI_MODEL = "anthropic/claude-sonnet-4-20250514";
+const ADMIN_AI_MODEL = "anthropic/claude-sonnet-latest";
 const SESSION_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
 const ACTION_DELAY_MS = 300;
+const MAX_TOOL_LOOP_ITERATIONS = 5;
 
 const pendingActions = new Map<string, PendingAdminAction>();
 
@@ -66,53 +69,86 @@ export function handleAdminAI(client: Client<true>): void {
 			const guildContext = gatherGuildContext(message.guild);
 			const systemPrompt = buildSystemPrompt(guildContext);
 
-			// Call Claude via OpenRouter
-			const response = await ai.chat.completions.create({
-				model: ADMIN_AI_MODEL,
-				messages: [
-					{ role: "system", content: systemPrompt },
-					{ role: "user", content },
-				],
-				tools: adminToolDefinitions,
-				temperature: 0,
-			});
+			// Walk reply chain to reconstruct prior conversation with this admin
+			const history = await gatherConversationHistory(message, client.user.id);
 
-			const choice = response.choices[0];
-			if (!choice) {
-				await message.reply("Nedostal jsem odpoved od AI.");
-				return;
+			const messages: ChatCompletionMessageParam[] = [
+				{ role: "system", content: systemPrompt },
+				...history.map<ChatCompletionMessageParam>((h) => ({ role: h.role, content: h.content })),
+				{ role: "user", content },
+			];
+
+			// Multi-step tool loop: info tools execute inline, action tools collect for confirmation
+			let actions: PlannedAction[] = [];
+			let finalText: string | null = null;
+
+			// eslint-disable-next-line no-await-in-loop -- Each AI call depends on prior tool results
+			for (let iter = 0; iter < MAX_TOOL_LOOP_ITERATIONS; iter++) {
+				const response = await ai.chat.completions.create({
+					model: ADMIN_AI_MODEL,
+					messages,
+					tools: adminToolDefinitions,
+					temperature: 0,
+				});
+
+				const choice = response.choices[0];
+				if (!choice) {
+					finalText = "Nedostal jsem odpoved od AI.";
+					break;
+				}
+
+				const assistantMessage = choice.message;
+				const functionCalls = (assistantMessage.tool_calls ?? []).filter((tc) => tc.type === "function");
+
+				if (functionCalls.length === 0) {
+					finalText = assistantMessage.content ?? "Nemam co odpovedet.";
+					break;
+				}
+
+				const actionCalls = functionCalls.filter((tc) => !INFO_TOOLS.has(tc.function.name));
+				const infoCalls = functionCalls.filter((tc) => INFO_TOOLS.has(tc.function.name));
+
+				if (actionCalls.length > 0) {
+					actions = actionCalls.map((tc) => {
+						const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+						return {
+							toolCallId: tc.id,
+							functionName: tc.function.name,
+							arguments: args,
+							displaySummary: generateActionSummary(tc.function.name, args, guildContext),
+						};
+					});
+					finalText = assistantMessage.content ?? null;
+					break;
+				}
+
+				// All info tools — execute, feed results back, loop
+				messages.push({
+					role: "assistant",
+					content: assistantMessage.content ?? null,
+					tool_calls: assistantMessage.tool_calls,
+				});
+
+				// eslint-disable-next-line no-await-in-loop -- Sequential tool execution to preserve order
+				for (const ic of infoCalls) {
+					const args = JSON.parse(ic.function.arguments) as Record<string, unknown>;
+					const result = await executeInfoTool(message.guild, ic.function.name, args);
+					messages.push({
+						role: "tool",
+						tool_call_id: ic.id,
+						content: result,
+					});
+				}
 			}
-
-			const assistantMessage = choice.message;
-
-			// If text-only response (clarification/refusal)
-			if (!assistantMessage.tool_calls || assistantMessage.tool_calls.length === 0) {
-				const textContent = assistantMessage.content ?? "Nemam co odpovedet.";
-				await message.reply(textContent);
-				return;
-			}
-
-			// Parse function tool calls into planned actions
-			const functionCalls = assistantMessage.tool_calls.filter((tc) => tc.type === "function");
-			const actions: PlannedAction[] = functionCalls.map((tc) => {
-				const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
-				return {
-					toolCallId: tc.id,
-					functionName: tc.function.name,
-					arguments: args,
-					displaySummary: generateActionSummary(tc.function.name, args, guildContext),
-				};
-			});
 
 			if (actions.length === 0) {
-				const textContent = assistantMessage.content ?? "Nemam co odpovedet.";
-				await message.reply(textContent);
+				await message.reply(finalText ?? "Nemam co odpovedet.");
 				return;
 			}
 
-			// Build preview
+			// Build preview for action confirmation
 			const sessionId = generateSessionId();
-			const previewEmbed = buildPreviewEmbed(actions, assistantMessage.content ?? undefined);
+			const previewEmbed = buildPreviewEmbed(actions, finalText ?? undefined);
 			const buttons = buildConfirmButtons(sessionId);
 
 			const reply = await message.reply({
@@ -120,7 +156,6 @@ export function handleAdminAI(client: Client<true>): void {
 				components: [buttons.toJSON()],
 			});
 
-			// Store pending action
 			pendingActions.set(sessionId, {
 				id: sessionId,
 				guildId: message.guild.id,

--- a/src/handlers/handleAdminAI.ts
+++ b/src/handlers/handleAdminAI.ts
@@ -108,37 +108,58 @@ export function handleAdminAI(client: Client<true>): void {
 				const actionCalls = functionCalls.filter((tc) => !INFO_TOOLS.has(tc.function.name));
 				const infoCalls = functionCalls.filter((tc) => INFO_TOOLS.has(tc.function.name));
 
-				if (actionCalls.length > 0) {
-					actions = actionCalls.map((tc) => {
-						const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
-						return {
-							toolCallId: tc.id,
-							functionName: tc.function.name,
-							arguments: args,
-							displaySummary: generateActionSummary(tc.function.name, args, guildContext),
-						};
-					});
-					finalText = assistantMessage.content ?? null;
-					break;
-				}
-
-				// All info tools — execute, feed results back, loop
-				messages.push({
-					role: "assistant",
-					content: assistantMessage.content ?? null,
-					tool_calls: assistantMessage.tool_calls,
-				});
-
-				// eslint-disable-next-line no-await-in-loop -- Sequential tool execution to preserve order
-				for (const ic of infoCalls) {
-					const args = JSON.parse(ic.function.arguments) as Record<string, unknown>;
-					const result = await executeInfoTool(message.guild, ic.function.name, args);
+				// If model returned info calls (alone or mixed with actions), execute
+				// them FIRST and feed results back. The OpenAI tool-call protocol
+				// requires a tool result for every tool_call in the assistant message
+				// before the next assistant turn — so when we have info calls, we
+				// must satisfy ALL tool_calls (including action ones with a stub
+				// result) before looping. Discarding the action plan here is correct:
+				// the model gets fresh info on the next iteration and re-plans.
+				if (infoCalls.length > 0) {
 					messages.push({
-						role: "tool",
-						tool_call_id: ic.id,
-						content: result,
+						role: "assistant",
+						content: assistantMessage.content ?? null,
+						tool_calls: assistantMessage.tool_calls,
 					});
+
+					// eslint-disable-next-line no-await-in-loop -- Sequential tool execution to preserve order
+					for (const ic of infoCalls) {
+						const args = JSON.parse(ic.function.arguments) as Record<string, unknown>;
+						const result = await executeInfoTool(message.guild, ic.function.name, args);
+						messages.push({
+							role: "tool",
+							tool_call_id: ic.id,
+							content: result,
+						});
+					}
+
+					// Stub results for action tool_calls so the protocol stays valid.
+					// The action plan from this turn is intentionally discarded; the
+					// model will re-plan on the next iteration with the info results
+					// in context.
+					for (const ac of actionCalls) {
+						messages.push({
+							role: "tool",
+							tool_call_id: ac.id,
+							content: "(deferred: action plans must be issued in a separate turn after info results)",
+						});
+					}
+
+					continue;
 				}
+
+				// Pure action turn — plan for confirmation and exit loop
+				actions = actionCalls.map((tc) => {
+					const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+					return {
+						toolCallId: tc.id,
+						functionName: tc.function.name,
+						arguments: args,
+						displaySummary: generateActionSummary(tc.function.name, args, guildContext),
+					};
+				});
+				finalText = assistantMessage.content ?? null;
+				break;
 			}
 
 			if (actions.length === 0) {

--- a/src/services/adminAI/actionPreview.ts
+++ b/src/services/adminAI/actionPreview.ts
@@ -18,15 +18,16 @@ export function buildPreviewEmbed(actions: PlannedAction[], aiMessage?: string):
 }
 
 export function buildConfirmButtons(sessionId: string): ActionRowBuilder {
+	// Note: emoji omitted because @discordjs/builders v2 prerelease validator
+	// rejects single-codepoint unicode emoji names (>=2 chars required, bug).
+	// Label-only buttons render fine in Discord.
 	const confirmButton = new PrimaryButtonBuilder()
 		.setCustomId(`admin_ai_confirm_${sessionId}`)
-		.setLabel("Potvrdit")
-		.setEmoji({ name: "✅" });
+		.setLabel("✅ Potvrdit");
 
 	const cancelButton = new DangerButtonBuilder()
 		.setCustomId(`admin_ai_cancel_${sessionId}`)
-		.setLabel("Zrusit")
-		.setEmoji({ name: "❌" });
+		.setLabel("❌ Zrusit");
 
 	return new ActionRowBuilder().addComponents(confirmButton, cancelButton);
 }

--- a/src/services/adminAI/conversationHistory.test.ts
+++ b/src/services/adminAI/conversationHistory.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Message } from "discord.js";
+import { gatherConversationHistory } from "./conversationHistory.ts";
+
+const BOT_ID = "bot-1";
+const USER_ID = "user-1";
+
+interface FakeMessage {
+	id: string;
+	authorId: string;
+	content: string;
+	embeds: Array<{ description?: string; title?: string }>;
+	parentId: string | null;
+}
+
+function buildChain(messages: FakeMessage[]): Message {
+	const byId = new Map(messages.map((m) => [m.id, m]));
+
+	function toDiscordMessage(m: FakeMessage): Message {
+		const reference = m.parentId ? { messageId: m.parentId } : null;
+		const fetchReference = mock(async () => {
+			const parent = m.parentId ? byId.get(m.parentId) : null;
+			if (!parent) throw new Error("not found");
+			return toDiscordMessage(parent);
+		});
+
+		return {
+			id: m.id,
+			author: { id: m.authorId },
+			content: m.content,
+			embeds: m.embeds,
+			reference,
+			fetchReference,
+		} as unknown as Message;
+	}
+
+	const last = messages.at(-1);
+	if (!last) throw new Error("empty chain");
+	return toDiscordMessage(last);
+}
+
+describe("gatherConversationHistory", () => {
+	it("returns empty when message has no reference", async () => {
+		const msg = buildChain([
+			{ id: "m1", authorId: USER_ID, content: "hi", embeds: [], parentId: null },
+		]);
+
+		const result = await gatherConversationHistory(msg, BOT_ID);
+
+		expect(result).toEqual([]);
+	});
+
+	it("walks single bot reply", async () => {
+		const msg = buildChain([
+			{ id: "m1", authorId: USER_ID, content: `<@${BOT_ID}> add channel`, embeds: [], parentId: null },
+			{ id: "m2", authorId: BOT_ID, content: "Which category?", embeds: [], parentId: "m1" },
+			{ id: "m3", authorId: USER_ID, content: `<@${BOT_ID}> Main`, embeds: [], parentId: "m2" },
+		]);
+
+		const result = await gatherConversationHistory(msg, BOT_ID);
+
+		expect(result).toEqual([
+			{ role: "user", content: "add channel" },
+			{ role: "assistant", content: "Which category?" },
+		]);
+	});
+
+	it("strips bot mention from user messages", async () => {
+		const msg = buildChain([
+			{ id: "m1", authorId: USER_ID, content: `hello <@!${BOT_ID}> world`, embeds: [], parentId: null },
+			{ id: "m2", authorId: BOT_ID, content: "ack", embeds: [], parentId: "m1" },
+			{ id: "m3", authorId: USER_ID, content: "follow up", embeds: [], parentId: "m2" },
+		]);
+
+		const result = await gatherConversationHistory(msg, BOT_ID);
+
+		expect(result[0]).toEqual({ role: "user", content: "hello  world" });
+	});
+
+	it("stops walking when chain reaches a third party", async () => {
+		const msg = buildChain([
+			{ id: "m0", authorId: "stranger", content: "unrelated", embeds: [], parentId: null },
+			{ id: "m1", authorId: USER_ID, content: "ask", embeds: [], parentId: "m0" },
+			{ id: "m2", authorId: BOT_ID, content: "reply", embeds: [], parentId: "m1" },
+			{ id: "m3", authorId: USER_ID, content: "more", embeds: [], parentId: "m2" },
+		]);
+
+		const result = await gatherConversationHistory(msg, BOT_ID);
+
+		expect(result).toEqual([
+			{ role: "user", content: "ask" },
+			{ role: "assistant", content: "reply" },
+		]);
+	});
+
+	it("represents embed-only bot messages with a stub", async () => {
+		const msg = buildChain([
+			{ id: "m1", authorId: USER_ID, content: "create chan", embeds: [], parentId: null },
+			{
+				id: "m2",
+				authorId: BOT_ID,
+				content: "",
+				embeds: [{ description: "Create text channel \"foo\" in Main" }],
+				parentId: "m1",
+			},
+			{ id: "m3", authorId: USER_ID, content: "wait, change name", embeds: [], parentId: "m2" },
+		]);
+
+		const result = await gatherConversationHistory(msg, BOT_ID);
+
+		expect(result[1]?.role).toBe("assistant");
+		expect(result[1]?.content).toContain("predchozi navrh akci");
+		expect(result[1]?.content).toContain("foo");
+	});
+
+	it("caps depth at 10 hops", async () => {
+		const chain: FakeMessage[] = [];
+		for (let i = 0; i < 15; i++) {
+			chain.push({
+				id: `m${i}`,
+				authorId: i % 2 === 0 ? USER_ID : BOT_ID,
+				content: `msg ${i}`,
+				embeds: [],
+				parentId: i === 0 ? null : `m${i - 1}`,
+			});
+		}
+		const msg = buildChain(chain);
+
+		const result = await gatherConversationHistory(msg, BOT_ID);
+
+		expect(result.length).toBeLessThanOrEqual(10);
+	});
+});

--- a/src/services/adminAI/conversationHistory.ts
+++ b/src/services/adminAI/conversationHistory.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-await-in-loop -- Sequential walk: each fetch depends on the previous reference */
+import type { Message } from "discord.js";
+import { createLogger } from "../../util/logger.ts";
+
+const log = createLogger("AdminAI");
+
+const MAX_HISTORY_DEPTH = 10;
+
+export interface HistoryMessage {
+	role: "user" | "assistant";
+	content: string;
+}
+
+export async function gatherConversationHistory(
+	message: Message,
+	botUserId: string,
+): Promise<HistoryMessage[]> {
+	const history: HistoryMessage[] = [];
+	let current = await safeFetchReference(message);
+	let depth = 0;
+
+	while (current && depth < MAX_HISTORY_DEPTH) {
+		const isBot = current.author.id === botUserId;
+		const isOriginalAsker = current.author.id === message.author.id;
+
+		if (!isBot && !isOriginalAsker) {
+			break;
+		}
+
+		const content = extractContent(current, botUserId);
+		if (content) {
+			history.unshift({
+				role: isBot ? "assistant" : "user",
+				content,
+			});
+		}
+
+		current = await safeFetchReference(current);
+		depth++;
+	}
+
+	return history;
+}
+
+async function safeFetchReference(message: Message): Promise<Message | null> {
+	if (!message.reference?.messageId) return null;
+	try {
+		return await message.fetchReference();
+	} catch (error) {
+		log("warn", "Failed to fetch message reference:", error);
+		return null;
+	}
+}
+
+function extractContent(message: Message, botUserId: string): string {
+	let content = message.content
+		.replace(new RegExp(`<@!?${botUserId}>`, "g"), "")
+		.trim();
+
+	if (!content && message.embeds.length > 0) {
+		const first = message.embeds[0];
+		if (first?.description) {
+			content = `(predchozi navrh akci: ${first.description.slice(0, 500)})`;
+		} else if (first?.title) {
+			content = `(${first.title})`;
+		}
+	}
+
+	return content;
+}

--- a/src/services/adminAI/prompt.test.ts
+++ b/src/services/adminAI/prompt.test.ts
@@ -61,6 +61,18 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("NEVER guess");
 	});
 
+	it("includes strict clarification rule for ambiguous tokens", () => {
+		const prompt = buildSystemPrompt(testContext);
+
+		expect(prompt).toContain("STRICT CLARIFICATION RULE");
+	});
+
+	it("notes that new channels inherit category permissions", () => {
+		const prompt = buildSystemPrompt(testContext);
+
+		expect(prompt).toContain("inherit the category's permission overwrites");
+	});
+
 	it("includes instruction to respond in Czech", () => {
 		const prompt = buildSystemPrompt(testContext);
 

--- a/src/services/adminAI/prompt.ts
+++ b/src/services/adminAI/prompt.ts
@@ -22,6 +22,11 @@ Your job is to interpret admin requests and call the provided tools to make chan
 - Respond in Czech for any text messages.
 - Use exact names from the context for tool arguments.
 - If the request is unclear or you need more information, respond with a text message asking for clarification instead of calling tools.
+- STRICT CLARIFICATION RULE: If the admin's message contains any token (number, name, code, abbreviation, or identifier) that you cannot unambiguously resolve against the channel/role lists below, you MUST stop and ask the admin what it means before planning any action. Examples of ambiguous tokens: a bare number that is not a known channel/category/role ID, a name that does not match anything in the lists, an abbreviation, a typo, "this/that/there" without an obvious referent. Do not guess — ask.
+- New channels created with create_channel inherit the category's permission overwrites by default. If the admin says "follow current channels as example" or wants the new channel to match a sibling exactly (perms, topic, slowmode, NSFW), prefer clone_channel over create_channel — it copies all per-channel overrides.
+- delete_channel is DESTRUCTIVE and irreversible. Always describe what will be lost (channel name, message history) in your text response and require the admin to be explicit ("delete #foo", not just "remove that").
+- For assign_role / remove_role, the admin must mention the member with @user or provide their Discord ID. If the member is not unambiguously identified, ask.
+- query_audit_log is a READ-ONLY info tool. It executes immediately without confirmation and returns audit log text. Use it to answer "kdo udělal X" questions. Call it ALONE in one turn when you need historical data, then plan any follow-up actions in the next turn (do not mix info and action tool calls in the same turn).
 - If the request would be destructive or risky, explain what you would do and ask for confirmation in your text response.
 
 # Current Server Channels

--- a/src/services/adminAI/tools.test.ts
+++ b/src/services/adminAI/tools.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, it } from "bun:test";
 import {
 	adminToolDefinitions,
 	generateActionSummary,
+	INFO_TOOLS,
 	PERMISSION_MAP,
 } from "./tools.ts";
 import {
+	AssignRoleArgsSchema,
+	CloneChannelArgsSchema,
+	CreateCategoryArgsSchema,
 	CreateChannelArgsSchema,
+	DeleteChannelArgsSchema,
 	MoveChannelArgsSchema,
+	QueryAuditLogArgsSchema,
+	RemoveRoleArgsSchema,
 	RenameChannelArgsSchema,
 	SetChannelPermissionArgsSchema,
 } from "./types.ts";
@@ -26,8 +33,8 @@ const testContext: GuildContext = {
 };
 
 describe("adminToolDefinitions", () => {
-	it("has 4 tool definitions", () => {
-		expect(adminToolDefinitions).toHaveLength(4);
+	it("has 10 tool definitions", () => {
+		expect(adminToolDefinitions).toHaveLength(10);
 	});
 
 	it("all tools have type function", () => {
@@ -61,6 +68,48 @@ describe("adminToolDefinitions", () => {
 	it("includes rename_channel tool", () => {
 		const tool = adminToolDefinitions.find((t) => t.function.name === "rename_channel");
 		expect(tool).toBeDefined();
+	});
+
+	it("includes clone_channel tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "clone_channel");
+		expect(tool).toBeDefined();
+	});
+
+	it("includes delete_channel tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "delete_channel");
+		expect(tool).toBeDefined();
+	});
+
+	it("includes create_category tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "create_category");
+		expect(tool).toBeDefined();
+	});
+
+	it("includes assign_role tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "assign_role");
+		expect(tool).toBeDefined();
+	});
+
+	it("includes remove_role tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "remove_role");
+		expect(tool).toBeDefined();
+	});
+
+	it("includes query_audit_log tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "query_audit_log");
+		expect(tool).toBeDefined();
+	});
+});
+
+describe("INFO_TOOLS", () => {
+	it("contains query_audit_log", () => {
+		expect(INFO_TOOLS.has("query_audit_log")).toBe(true);
+	});
+
+	it("does not contain action tools", () => {
+		expect(INFO_TOOLS.has("create_channel")).toBe(false);
+		expect(INFO_TOOLS.has("delete_channel")).toBe(false);
+		expect(INFO_TOOLS.has("assign_role")).toBe(false);
 	});
 });
 
@@ -171,6 +220,116 @@ describe("Zod schemas", () => {
 			expect(result.success).toBe(false);
 		});
 	});
+
+	describe("CloneChannelArgsSchema", () => {
+		it("accepts valid args", () => {
+			const result = CloneChannelArgsSchema.safeParse({
+				source_channel_id: "ch-1",
+				new_name: "tiskar",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts optional position", () => {
+			const result = CloneChannelArgsSchema.safeParse({
+				source_channel_id: "ch-1",
+				new_name: "tiskar",
+				position: 5,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects missing source_channel_id", () => {
+			const result = CloneChannelArgsSchema.safeParse({ new_name: "tiskar" });
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("DeleteChannelArgsSchema", () => {
+		it("accepts valid args", () => {
+			const result = DeleteChannelArgsSchema.safeParse({ channel_id: "ch-1" });
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects missing channel_id", () => {
+			const result = DeleteChannelArgsSchema.safeParse({});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("CreateCategoryArgsSchema", () => {
+		it("accepts valid args", () => {
+			const result = CreateCategoryArgsSchema.safeParse({ name: "Public" });
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts optional position", () => {
+			const result = CreateCategoryArgsSchema.safeParse({ name: "Public", position: 0 });
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects missing name", () => {
+			const result = CreateCategoryArgsSchema.safeParse({});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("AssignRoleArgsSchema", () => {
+		it("accepts valid args", () => {
+			const result = AssignRoleArgsSchema.safeParse({
+				member_id: "user-1",
+				role_id: "role-1",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects missing role_id", () => {
+			const result = AssignRoleArgsSchema.safeParse({ member_id: "user-1" });
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("RemoveRoleArgsSchema", () => {
+		it("accepts valid args", () => {
+			const result = RemoveRoleArgsSchema.safeParse({
+				member_id: "user-1",
+				role_id: "role-1",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects missing member_id", () => {
+			const result = RemoveRoleArgsSchema.safeParse({ role_id: "role-1" });
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("QueryAuditLogArgsSchema", () => {
+		it("accepts empty args (no filters)", () => {
+			const result = QueryAuditLogArgsSchema.safeParse({});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts all optional fields", () => {
+			const result = QueryAuditLogArgsSchema.safeParse({
+				action_types: ["ChannelDelete"],
+				limit: 10,
+				target_id: "ch-1",
+				user_id: "user-1",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects limit above 50", () => {
+			const result = QueryAuditLogArgsSchema.safeParse({ limit: 100 });
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects limit below 1", () => {
+			const result = QueryAuditLogArgsSchema.safeParse({ limit: 0 });
+			expect(result.success).toBe(false);
+		});
+	});
 });
 
 describe("PERMISSION_MAP", () => {
@@ -272,5 +431,64 @@ describe("generateActionSummary", () => {
 		const summary = generateActionSummary("unknown_tool", {}, testContext);
 
 		expect(summary).toContain("Unknown action");
+	});
+
+	it("summarizes clone_channel action", () => {
+		const summary = generateActionSummary(
+			"clone_channel",
+			{ source_channel_id: "ch-1", new_name: "tiskar" },
+			testContext,
+		);
+
+		expect(summary).toContain("Clone");
+		expect(summary).toContain("#general");
+		expect(summary).toContain('"tiskar"');
+	});
+
+	it("summarizes delete_channel action with destructive marker", () => {
+		const summary = generateActionSummary(
+			"delete_channel",
+			{ channel_id: "ch-1" },
+			testContext,
+		);
+
+		expect(summary).toContain("DELETE");
+		expect(summary).toContain("irreversible");
+		expect(summary).toContain("#general");
+	});
+
+	it("summarizes create_category action", () => {
+		const summary = generateActionSummary(
+			"create_category",
+			{ name: "New Cat" },
+			testContext,
+		);
+
+		expect(summary).toContain("Create category");
+		expect(summary).toContain('"New Cat"');
+	});
+
+	it("summarizes assign_role action with known role", () => {
+		const summary = generateActionSummary(
+			"assign_role",
+			{ member_id: "user-1", role_id: "role-1" },
+			testContext,
+		);
+
+		expect(summary).toContain("Assign");
+		expect(summary).toContain("@Admin");
+		expect(summary).toContain("<@user-1>");
+	});
+
+	it("summarizes remove_role action", () => {
+		const summary = generateActionSummary(
+			"remove_role",
+			{ member_id: "user-1", role_id: "role-2" },
+			testContext,
+		);
+
+		expect(summary).toContain("Remove");
+		expect(summary).toContain("@Member");
+		expect(summary).toContain("<@user-1>");
 	});
 });

--- a/src/services/adminAI/tools.ts
+++ b/src/services/adminAI/tools.ts
@@ -462,26 +462,48 @@ async function executeQueryAuditLog(guild: Guild, args: Record<string, unknown>)
 	const parsed = QueryAuditLogArgsSchema.parse(args);
 
 	const limit = parsed.limit ?? 20;
-	const primaryType = parsed.action_types?.[0];
-	const typeFilter = primaryType ? resolveAuditLogEvent(primaryType) : null;
+	// Discord's fetchAuditLogs accepts only ONE action type per call. To honor
+	// multiple action_types correctly, fan out to one fetch per type and merge
+	// the results client-side. Single-type and no-type cases use one fetch.
+	const requestedTypes = parsed.action_types ?? [];
+	const fetches: Promise<Array<import("discord.js").GuildAuditLogsEntry>>[] = [];
 
-	const fetchOptions: { limit: number; type?: AuditLogEvent; user?: string } = { limit };
-	if (typeFilter !== null) fetchOptions.type = typeFilter;
-	if (parsed.user_id) fetchOptions.user = parsed.user_id;
+	if (requestedTypes.length === 0) {
+		const opts: { limit: number; user?: string } = { limit };
+		if (parsed.user_id) opts.user = parsed.user_id;
+		fetches.push(
+			guild.fetchAuditLogs(opts).then((logs) => [...logs.entries.values()]),
+		);
+	} else {
+		for (const typeName of requestedTypes) {
+			const typeFilter = resolveAuditLogEvent(typeName);
+			if (typeFilter === null) continue; // skip unknown event names
+			const opts: { limit: number; type: AuditLogEvent; user?: string } = { limit, type: typeFilter };
+			if (parsed.user_id) opts.user = parsed.user_id;
+			fetches.push(
+				guild.fetchAuditLogs(opts).then((logs) => [...logs.entries.values()]),
+			);
+		}
+		if (fetches.length === 0) {
+			return `No valid action_types provided. Got: ${requestedTypes.join(", ")}.`;
+		}
+	}
 
-	const logs = await guild.fetchAuditLogs(fetchOptions);
-	let entries = [...logs.entries.values()];
+	const results = await Promise.all(fetches);
+	const seen = new Set<string>();
+	let entries = results.flat().filter((e) => {
+		if (seen.has(e.id)) return false;
+		seen.add(e.id);
+		return true;
+	});
 
 	if (parsed.target_id) {
 		entries = entries.filter((e) => e.targetId === parsed.target_id);
 	}
-	if (parsed.action_types && parsed.action_types.length > 1) {
-		const allowed = new Set(parsed.action_types);
-		entries = entries.filter((e) => {
-			const name = AuditLogEvent[e.action];
-			return name !== undefined && allowed.has(name);
-		});
-	}
+
+	// Sort newest first across the merged result set, then cap to limit
+	entries.sort((a, b) => b.createdTimestamp - a.createdTimestamp);
+	entries = entries.slice(0, limit);
 
 	if (entries.length === 0) {
 		return "No audit log entries match the filter.";

--- a/src/services/adminAI/tools.ts
+++ b/src/services/adminAI/tools.ts
@@ -1,4 +1,5 @@
 import {
+	AuditLogEvent,
 	ChannelType,
 	type Guild,
 	type GuildChannel,
@@ -7,12 +8,20 @@ import {
 } from "discord.js";
 import type { ActionResult, GuildContext } from "./types.ts";
 import {
+	AssignRoleArgsSchema,
+	CloneChannelArgsSchema,
+	CreateCategoryArgsSchema,
 	CreateChannelArgsSchema,
+	DeleteChannelArgsSchema,
 	MoveChannelArgsSchema,
+	QueryAuditLogArgsSchema,
+	RemoveRoleArgsSchema,
 	RenameChannelArgsSchema,
 	SetChannelPermissionArgsSchema,
 } from "./types.ts";
 import type { ChatCompletionFunctionTool } from "openai/resources/chat/completions";
+
+export const INFO_TOOLS: ReadonlySet<string> = new Set(["query_audit_log"]);
 
 export const adminToolDefinitions: ChatCompletionFunctionTool[] = [
 	{
@@ -85,6 +94,102 @@ export const adminToolDefinitions: ChatCompletionFunctionTool[] = [
 					new_name: { type: "string", description: "New name for the channel" },
 				},
 				required: ["channel_id", "new_name"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "clone_channel",
+			description: "Clone an existing channel — copies type, topic, slowmode, NSFW flag, and per-channel permission overwrites from the source. Use this when admin says 'follow current channels as example' or wants a new channel matching siblings.",
+			parameters: {
+				type: "object",
+				properties: {
+					source_channel_id: { type: "string", description: "ID of the channel to clone from" },
+					new_name: { type: "string", description: "Name for the new channel" },
+					position: { type: "number", description: "Position for the new channel (optional)" },
+				},
+				required: ["source_channel_id", "new_name"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "delete_channel",
+			description: "Delete a channel permanently. DESTRUCTIVE — cannot be undone. Always explain what will be lost in your text response.",
+			parameters: {
+				type: "object",
+				properties: {
+					channel_id: { type: "string", description: "Channel ID to delete" },
+				},
+				required: ["channel_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "create_category",
+			description: "Create a new category (top-level container for channels)",
+			parameters: {
+				type: "object",
+				properties: {
+					name: { type: "string", description: "Category name" },
+					position: { type: "number", description: "Category position (optional)" },
+				},
+				required: ["name"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "assign_role",
+			description: "Assign a role to a guild member",
+			parameters: {
+				type: "object",
+				properties: {
+					member_id: { type: "string", description: "Discord user ID of the member" },
+					role_id: { type: "string", description: "ID of the role to assign" },
+				},
+				required: ["member_id", "role_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "remove_role",
+			description: "Remove a role from a guild member",
+			parameters: {
+				type: "object",
+				properties: {
+					member_id: { type: "string", description: "Discord user ID of the member" },
+					role_id: { type: "string", description: "ID of the role to remove" },
+				},
+				required: ["member_id", "role_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "query_audit_log",
+			description: "READ-ONLY info tool: query Discord audit log to find who did what. Use to answer questions like 'kdo smazal #foo', 'kdo banoval @user', 'kdo vytvořil tu kategorii'. Executes immediately without confirmation. Call this FIRST in its own turn when you need historical context, then plan actions in the next turn.",
+			parameters: {
+				type: "object",
+				properties: {
+					action_types: {
+						type: "array",
+						items: { type: "string" },
+						description: "Filter by Discord audit log event names (e.g. 'ChannelCreate', 'ChannelDelete', 'MemberKick', 'MemberBanAdd', 'RoleCreate', 'RoleDelete', 'MessageDelete'). Omit for all types.",
+					},
+					limit: { type: "number", description: "Max entries (1-50, default 20)" },
+					target_id: { type: "string", description: "Filter by target ID (channel/user/role/etc.)" },
+					user_id: { type: "string", description: "Filter by executor (who performed the action)" },
+				},
+				required: [],
 			},
 		},
 	},
@@ -243,12 +348,217 @@ async function executeRenameChannel(guild: Guild, args: Record<string, unknown>)
 	};
 }
 
+async function executeCloneChannel(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = CloneChannelArgsSchema.parse(args);
+	const source = guild.channels.cache.get(parsed.source_channel_id);
+
+	if (!source || !("clone" in source) || typeof source.clone !== "function") {
+		return {
+			toolCallId: "",
+			functionName: "clone_channel",
+			success: false,
+			message: `Source channel ${parsed.source_channel_id} not found or not cloneable`,
+		};
+	}
+
+	const cloned = await source.clone({ name: parsed.new_name });
+	if (parsed.position !== undefined && "setPosition" in cloned) {
+		await cloned.setPosition(parsed.position);
+	}
+
+	return {
+		toolCallId: "",
+		functionName: "clone_channel",
+		success: true,
+		message: `Cloned "${source.name}" to "${cloned.name}" (${cloned.id})`,
+	};
+}
+
+async function executeDeleteChannel(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = DeleteChannelArgsSchema.parse(args);
+	const channel = guild.channels.cache.get(parsed.channel_id) as GuildChannel | undefined;
+
+	if (!channel) {
+		return {
+			toolCallId: "",
+			functionName: "delete_channel",
+			success: false,
+			message: `Channel ${parsed.channel_id} not found`,
+		};
+	}
+
+	const name = channel.name;
+	await channel.delete();
+
+	return {
+		toolCallId: "",
+		functionName: "delete_channel",
+		success: true,
+		message: `Deleted channel "${name}"`,
+	};
+}
+
+async function executeCreateCategory(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = CreateCategoryArgsSchema.parse(args);
+
+	const category = await guild.channels.create({
+		name: parsed.name,
+		type: ChannelType.GuildCategory,
+		position: parsed.position,
+	});
+
+	return {
+		toolCallId: "",
+		functionName: "create_category",
+		success: true,
+		message: `Created category "${category.name}" (${category.id})`,
+	};
+}
+
+async function executeAssignRole(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = AssignRoleArgsSchema.parse(args);
+	const member = await guild.members.fetch(parsed.member_id).catch(() => null);
+
+	if (!member) {
+		return {
+			toolCallId: "",
+			functionName: "assign_role",
+			success: false,
+			message: `Member ${parsed.member_id} not found in this guild`,
+		};
+	}
+
+	const role = guild.roles.cache.get(parsed.role_id);
+	if (!role) {
+		return {
+			toolCallId: "",
+			functionName: "assign_role",
+			success: false,
+			message: `Role ${parsed.role_id} not found`,
+		};
+	}
+
+	await member.roles.add(role);
+
+	return {
+		toolCallId: "",
+		functionName: "assign_role",
+		success: true,
+		message: `Assigned role "${role.name}" to ${member.user.tag}`,
+	};
+}
+
+function resolveAuditLogEvent(name: string): AuditLogEvent | null {
+	const value = (AuditLogEvent as Record<string, string | number>)[name];
+	return typeof value === "number" ? (value as AuditLogEvent) : null;
+}
+
+function formatAuditLogTimestamp(ts: number): string {
+	const d = new Date(ts);
+	return d.toISOString().slice(0, 16).replace("T", " ");
+}
+
+async function executeQueryAuditLog(guild: Guild, args: Record<string, unknown>): Promise<string> {
+	const parsed = QueryAuditLogArgsSchema.parse(args);
+
+	const limit = parsed.limit ?? 20;
+	const primaryType = parsed.action_types?.[0];
+	const typeFilter = primaryType ? resolveAuditLogEvent(primaryType) : null;
+
+	const fetchOptions: { limit: number; type?: AuditLogEvent; user?: string } = { limit };
+	if (typeFilter !== null) fetchOptions.type = typeFilter;
+	if (parsed.user_id) fetchOptions.user = parsed.user_id;
+
+	const logs = await guild.fetchAuditLogs(fetchOptions);
+	let entries = [...logs.entries.values()];
+
+	if (parsed.target_id) {
+		entries = entries.filter((e) => e.targetId === parsed.target_id);
+	}
+	if (parsed.action_types && parsed.action_types.length > 1) {
+		const allowed = new Set(parsed.action_types);
+		entries = entries.filter((e) => {
+			const name = AuditLogEvent[e.action];
+			return name !== undefined && allowed.has(name);
+		});
+	}
+
+	if (entries.length === 0) {
+		return "No audit log entries match the filter.";
+	}
+
+	const lines = entries.map((e) => {
+		const ts = formatAuditLogTimestamp(e.createdTimestamp);
+		const action = AuditLogEvent[e.action] ?? `Action#${e.action}`;
+		const executor = e.executor ? `${e.executor.tag} (${e.executor.id})` : "unknown";
+		const target = e.targetId ?? "n/a";
+		const reason = e.reason ? ` - reason: ${e.reason}` : "";
+		return `${ts} UTC | ${action} | by ${executor} | target: ${target}${reason}`;
+	});
+
+	return lines.join("\n");
+}
+
+export async function executeInfoTool(
+	guild: Guild,
+	functionName: string,
+	args: Record<string, unknown>,
+): Promise<string> {
+	try {
+		if (functionName === "query_audit_log") {
+			return await executeQueryAuditLog(guild, args);
+		}
+		return `Unknown info tool: ${functionName}`;
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		return `Error executing ${functionName}: ${errorMessage}`;
+	}
+}
+
+async function executeRemoveRole(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = RemoveRoleArgsSchema.parse(args);
+	const member = await guild.members.fetch(parsed.member_id).catch(() => null);
+
+	if (!member) {
+		return {
+			toolCallId: "",
+			functionName: "remove_role",
+			success: false,
+			message: `Member ${parsed.member_id} not found in this guild`,
+		};
+	}
+
+	const role = guild.roles.cache.get(parsed.role_id);
+	if (!role) {
+		return {
+			toolCallId: "",
+			functionName: "remove_role",
+			success: false,
+			message: `Role ${parsed.role_id} not found`,
+		};
+	}
+
+	await member.roles.remove(role);
+
+	return {
+		toolCallId: "",
+		functionName: "remove_role",
+		success: true,
+		message: `Removed role "${role.name}" from ${member.user.tag}`,
+	};
+}
+
 export async function executeToolCall(guild: Guild, functionName: string, args: Record<string, unknown>): Promise<ActionResult> {
 	const executors: Record<string, (guild: Guild, args: Record<string, unknown>) => Promise<ActionResult>> = {
 		create_channel: executeCreateChannel,
 		set_channel_permission: executeSetChannelPermission,
 		move_channel: executeMoveChannel,
 		rename_channel: executeRenameChannel,
+		clone_channel: executeCloneChannel,
+		delete_channel: executeDeleteChannel,
+		create_category: executeCreateCategory,
+		assign_role: executeAssignRole,
+		remove_role: executeRemoveRole,
 	};
 
 	const executor = executors[functionName];
@@ -311,6 +621,32 @@ export function generateActionSummary(functionName: string, args: Record<string,
 		case "rename_channel": {
 			const a = args as { channel_id: string; new_name: string };
 			return `Rename ${resolveChannelName(a.channel_id)} to "${a.new_name}"`;
+		}
+		case "clone_channel": {
+			const a = args as { source_channel_id: string; new_name: string; position?: number };
+			const posStr = a.position !== undefined ? ` at position ${a.position}` : "";
+			return `Clone ${resolveChannelName(a.source_channel_id)} as "${a.new_name}"${posStr}`;
+		}
+		case "delete_channel": {
+			const a = args as { channel_id: string };
+			return `⚠️ DELETE ${resolveChannelName(a.channel_id)} (irreversible)`;
+		}
+		case "create_category": {
+			const a = args as { name: string; position?: number };
+			const posStr = a.position !== undefined ? ` at position ${a.position}` : "";
+			return `Create category "${a.name}"${posStr}`;
+		}
+		case "assign_role": {
+			const a = args as { member_id: string; role_id: string };
+			const role = guildContext.roles.find((r) => r.id === a.role_id);
+			const roleStr = role ? `@${role.name}` : `<@&${a.role_id}>`;
+			return `Assign ${roleStr} to <@${a.member_id}>`;
+		}
+		case "remove_role": {
+			const a = args as { member_id: string; role_id: string };
+			const role = guildContext.roles.find((r) => r.id === a.role_id);
+			const roleStr = role ? `@${role.name}` : `<@&${a.role_id}>`;
+			return `Remove ${roleStr} from <@${a.member_id}>`;
 		}
 		default:
 			return `Unknown action: ${functionName}`;

--- a/src/services/adminAI/types.ts
+++ b/src/services/adminAI/types.ts
@@ -55,6 +55,50 @@ export const RenameChannelArgsSchema = z.object({
 
 export type RenameChannelArgs = z.infer<typeof RenameChannelArgsSchema>;
 
+export const CloneChannelArgsSchema = z.object({
+	source_channel_id: z.string(),
+	new_name: z.string(),
+	position: z.number().optional(),
+});
+
+export type CloneChannelArgs = z.infer<typeof CloneChannelArgsSchema>;
+
+export const DeleteChannelArgsSchema = z.object({
+	channel_id: z.string(),
+});
+
+export type DeleteChannelArgs = z.infer<typeof DeleteChannelArgsSchema>;
+
+export const CreateCategoryArgsSchema = z.object({
+	name: z.string(),
+	position: z.number().optional(),
+});
+
+export type CreateCategoryArgs = z.infer<typeof CreateCategoryArgsSchema>;
+
+export const AssignRoleArgsSchema = z.object({
+	member_id: z.string(),
+	role_id: z.string(),
+});
+
+export type AssignRoleArgs = z.infer<typeof AssignRoleArgsSchema>;
+
+export const RemoveRoleArgsSchema = z.object({
+	member_id: z.string(),
+	role_id: z.string(),
+});
+
+export type RemoveRoleArgs = z.infer<typeof RemoveRoleArgsSchema>;
+
+export const QueryAuditLogArgsSchema = z.object({
+	action_types: z.array(z.string()).optional(),
+	limit: z.number().int().min(1).max(50).optional(),
+	target_id: z.string().optional(),
+	user_id: z.string().optional(),
+});
+
+export type QueryAuditLogArgs = z.infer<typeof QueryAuditLogArgsSchema>;
+
 export interface PlannedAction {
 	toolCallId: string;
 	functionName: string;


### PR DESCRIPTION
## Summary

Two patch releases bundled:

**v2.8.3** — Conversation memory + invalid model ID fix
- Fix: Admin AI was using `anthropic/claude-sonnet-4-20250514` which OpenRouter rejects with HTTP 400. Switched to `anthropic/claude-sonnet-latest` so the bot auto-tracks the newest Sonnet without manual bumps.
- Feat: Walks the Discord reply chain (max 10 hops) to reconstruct prior turns. Admin can now have multi-turn clarification conversations — ask, get a follow-up question, reply with the answer, bot has full context. Chain is restricted to bot + the triggering admin so third-party messages never enter the model context.
- Prompt: strict clarification rule — bot must ask before acting on any token it cannot unambiguously resolve against guild context (channels/roles/categories).

**v2.8.4** — 5 new tools + audit-log query + multi-step tool loop
- `clone_channel` — full sibling clone (type, topic, slowmode, NSFW, per-channel permission overwrites). Closes the "follow current channels as example" use case where `create_channel` could only inherit category-level perms.
- `delete_channel` — destructive, marked `⚠️ DELETE … (irreversible)` in the preview.
- `create_category` — top-level category creation.
- `assign_role` / `remove_role` — fetches member, validates role, errors gracefully if missing.
- `query_audit_log` — read-only info tool that fetches Discord audit log with filters (action types, target ID, executor, limit). Answers questions like \"kdo smazal #foo\".
- Multi-step tool loop in handler (max 5 iterations): info tools execute inline and feed their results back to the model so it can reason on fresh data before planning irreversible actions. Action tools still require user confirmation via the existing button flow.
- `INFO_TOOLS` set separates read-only tools from action tools — easy to extend with future read-only queries.
- Fix: `@discordjs/builders` v2 prerelease validator rejected single-codepoint unicode emoji in `setEmoji`. Moved emoji into the button label text so action buttons send without 400-ing.

## Test plan

- [x] `bunx tsgo --noEmit` clean
- [x] `bunx oxlint --type-aware` no new warnings (3 pre-existing)
- [x] `bun test` — 1136 pass, 0 fail
- [ ] Smoke test in Discord: `@bot create channel \"tiskar\" via clone_channel from existing sibling`
- [ ] Smoke test: ask `@bot kdo smazal #foo` → bot calls `query_audit_log`, returns text answer
- [ ] Smoke test: ask `@bot do something with 316` → bot asks for clarification (strict rule)
- [ ] Smoke test: reply to bot's clarification message → bot uses prior context