### PR TITLE
fix(admin-ai): use ~-prefixed sonnet-latest slug (OpenRouter rejected unprefixed)

### DIFF
--- a/src/handlers/handleAdminAI.ts
+++ b/src/handlers/handleAdminAI.ts
@@ -13,7 +13,11 @@ import type { ChatCompletionMessageParam } from "openai/resources/chat/completio
 
 const log = createLogger("AdminAI");
 
-const ADMIN_AI_MODEL = "anthropic/claude-sonnet-latest";
+// `~anthropic/claude-sonnet-latest` is OpenRouter's auto-routing alias that
+// always redirects to the newest Sonnet. The `~` prefix is part of the slug
+// (OpenRouter's marker for variant/alias models) — without it OpenRouter
+// rejects the request with "not a valid model ID".
+const ADMIN_AI_MODEL = "~anthropic/claude-sonnet-latest";
 const SESSION_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
 const ACTION_DELAY_MS = 300;
 const MAX_TOOL_LOOP_ITERATIONS = 5;


### PR DESCRIPTION
## Summary

Production fired the same model-ID error v2.8.3 was supposed to fix:

\`\`\`
"message": "anthropic/claude-sonnet-latest is not a valid model ID",
"code": 400
\`\`\`

OpenRouter rejects the unprefixed slug. Their model listing actually shows the alias as **\`~anthropic/claude-sonnet-latest\`** — the \`~\` prefix is part of the slug (it marks alias / auto-routing models that redirect to the newest version in a family). The earlier WebFetch I used to research the slug stripped the prefix.

Switched the constant to the prefixed form.

## Test plan

- [x] \`bunx tsgo --noEmit\` clean
- [x] \`bun test src/handlers/\` 196/196 pass
- [ ] Smoke test: \`@bot\` mention in Discord — should no longer 400 from OpenRouter