### PR TITLE
feat(admin-ai): add update_channel tool (v2.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Formát je založen na [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- commits after XXX -->
 
 
+## [2.8.5] - 2026-05-03
+
+### Přidáno
+- Admin AI: nový nástroj `update_channel` — upravuje nastavení kanálu (topic/popis, slowmode v sekundách, NSFW flag, voice user limit, voice bitrate). Mění pouze pole, která admin výslovně požádal.
+
+
 ## [2.8.4] - 2026-05-03
 
 ### Přidáno

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "allcom-bot",
-	"version": "2.8.4",
+	"version": "2.8.5",
 	"description": "Allcom Discord bot with modular architecture",
 	"private": true,
 	"type": "module",

--- a/src/services/adminAI/prompt.ts
+++ b/src/services/adminAI/prompt.ts
@@ -27,6 +27,7 @@ Your job is to interpret admin requests and call the provided tools to make chan
 - delete_channel is DESTRUCTIVE and irreversible. Always describe what will be lost (channel name, message history) in your text response and require the admin to be explicit ("delete #foo", not just "remove that").
 - For assign_role / remove_role, the admin must mention the member with @user or provide their Discord ID. If the member is not unambiguously identified, ask.
 - query_audit_log is a READ-ONLY info tool. It executes immediately without confirmation and returns audit log text. Use it to answer "kdo udělal X" questions. Call it ALONE in one turn when you need historical data, then plan any follow-up actions in the next turn (do not mix info and action tool calls in the same turn).
+- update_channel changes a channel's settings (topic/description, slowmode, NSFW, voice user_limit, voice bitrate). Pass ONLY the fields the admin asked you to change — leave the rest unset so they keep their current values. Slowmode is in SECONDS (admin says "5 minutes" → pass 300). Bitrate is in BITS PER SECOND (admin says "64 kbps" → pass 64000). For voice-only fields (user_limit, bitrate), confirm the channel is a voice channel before calling.
 - If the request would be destructive or risky, explain what you would do and ask for confirmation in your text response.
 
 # Current Server Channels

--- a/src/services/adminAI/tools.test.ts
+++ b/src/services/adminAI/tools.test.ts
@@ -16,6 +16,7 @@ import {
 	RemoveRoleArgsSchema,
 	RenameChannelArgsSchema,
 	SetChannelPermissionArgsSchema,
+	UpdateChannelArgsSchema,
 } from "./types.ts";
 import type { GuildContext } from "./types.ts";
 
@@ -34,7 +35,7 @@ const testContext: GuildContext = {
 
 describe("adminToolDefinitions", () => {
 	it("has 10 tool definitions", () => {
-		expect(adminToolDefinitions).toHaveLength(10);
+		expect(adminToolDefinitions).toHaveLength(11);
 	});
 
 	it("all tools have type function", () => {
@@ -97,6 +98,11 @@ describe("adminToolDefinitions", () => {
 
 	it("includes query_audit_log tool", () => {
 		const tool = adminToolDefinitions.find((t) => t.function.name === "query_audit_log");
+		expect(tool).toBeDefined();
+	});
+
+	it("includes update_channel tool", () => {
+		const tool = adminToolDefinitions.find((t) => t.function.name === "update_channel");
 		expect(tool).toBeDefined();
 	});
 });
@@ -330,6 +336,79 @@ describe("Zod schemas", () => {
 			expect(result.success).toBe(false);
 		});
 	});
+
+	describe("UpdateChannelArgsSchema", () => {
+		it("accepts topic-only update", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				topic: "New description",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts slowmode-only update", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				slowmode_seconds: 300,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts topic=null to clear it", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				topic: null,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts multiple fields together", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				topic: "Voice room",
+				user_limit: 10,
+				bitrate: 64000,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects when no update fields are provided", () => {
+			const result = UpdateChannelArgsSchema.safeParse({ channel_id: "ch-1" });
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects slowmode above 21600 (Discord max)", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				slowmode_seconds: 30000,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects negative slowmode", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				slowmode_seconds: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects user_limit above 99 (Discord max)", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				user_limit: 200,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects topic over 1024 chars", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				topic: "a".repeat(1025),
+			});
+			expect(result.success).toBe(false);
+		});
+	});
 });
 
 describe("PERMISSION_MAP", () => {
@@ -490,5 +569,40 @@ describe("generateActionSummary", () => {
 		expect(summary).toContain("Remove");
 		expect(summary).toContain("@Member");
 		expect(summary).toContain("<@user-1>");
+	});
+
+	it("summarizes update_channel topic+slowmode", () => {
+		const summary = generateActionSummary(
+			"update_channel",
+			{ channel_id: "ch-1", topic: "New desc", slowmode_seconds: 60 },
+			testContext,
+		);
+
+		expect(summary).toContain("Update");
+		expect(summary).toContain("#general");
+		expect(summary).toContain('topic="New desc"');
+		expect(summary).toContain("slowmode=60s");
+	});
+
+	it("summarizes update_channel topic cleared (null)", () => {
+		const summary = generateActionSummary(
+			"update_channel",
+			{ channel_id: "ch-1", topic: null },
+			testContext,
+		);
+
+		expect(summary).toContain("topic=(cleared)");
+	});
+
+	it("summarizes update_channel voice fields", () => {
+		const summary = generateActionSummary(
+			"update_channel",
+			{ channel_id: "ch-1", user_limit: 5, bitrate: 64000, nsfw: true },
+			testContext,
+		);
+
+		expect(summary).toContain("user_limit=5");
+		expect(summary).toContain("bitrate=64000");
+		expect(summary).toContain("nsfw=true");
 	});
 });

--- a/src/services/adminAI/tools.test.ts
+++ b/src/services/adminAI/tools.test.ts
@@ -401,10 +401,29 @@ describe("Zod schemas", () => {
 			expect(result.success).toBe(false);
 		});
 
-		it("rejects topic over 1024 chars", () => {
+		it("accepts topic between 1025 and 4096 chars (forum/media long-form)", () => {
+			// 1024 is the text-channel cap; 4096 is the forum/media cap. Schema
+			// uses the wider limit so legitimate forum guideline updates aren't
+			// rejected client-side. Discord enforces the per-type cap server-side.
 			const result = UpdateChannelArgsSchema.safeParse({
 				channel_id: "ch-1",
-				topic: "a".repeat(1025),
+				topic: "a".repeat(2048),
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts topic at exactly 4096 chars (forum/media max)", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				topic: "a".repeat(4096),
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("rejects topic over 4096 chars (above any Discord cap)", () => {
+			const result = UpdateChannelArgsSchema.safeParse({
+				channel_id: "ch-1",
+				topic: "a".repeat(4097),
 			});
 			expect(result.success).toBe(false);
 		});

--- a/src/services/adminAI/tools.ts
+++ b/src/services/adminAI/tools.ts
@@ -109,7 +109,7 @@ export const adminToolDefinitions: ChatCompletionFunctionTool[] = [
 					channel_id: { type: "string", description: "Channel ID to update" },
 					topic: {
 						type: ["string", "null"],
-						description: "Channel topic / description (text/announcement/forum). Max 1024 chars. Pass null to clear.",
+						description: "Channel topic / description. Max 1024 chars on text/announcement channels; up to 4096 chars on forum/media channels (their long-form post guidelines). Pass null to clear.",
 					},
 					slowmode_seconds: {
 						type: "number",

--- a/src/services/adminAI/tools.ts
+++ b/src/services/adminAI/tools.ts
@@ -18,6 +18,7 @@ import {
 	RemoveRoleArgsSchema,
 	RenameChannelArgsSchema,
 	SetChannelPermissionArgsSchema,
+	UpdateChannelArgsSchema,
 } from "./types.ts";
 import type { ChatCompletionFunctionTool } from "openai/resources/chat/completions";
 
@@ -94,6 +95,37 @@ export const adminToolDefinitions: ChatCompletionFunctionTool[] = [
 					new_name: { type: "string", description: "New name for the channel" },
 				},
 				required: ["channel_id", "new_name"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "update_channel",
+			description: "Update a channel's settings: topic/description, slowmode, NSFW, voice user limit, voice bitrate. Pass only the fields you want to change. At least one field is required.",
+			parameters: {
+				type: "object",
+				properties: {
+					channel_id: { type: "string", description: "Channel ID to update" },
+					topic: {
+						type: ["string", "null"],
+						description: "Channel topic / description (text/announcement/forum). Max 1024 chars. Pass null to clear.",
+					},
+					slowmode_seconds: {
+						type: "number",
+						description: "Slowmode rate limit in seconds (0–21600, where 0 disables it). Text channels only.",
+					},
+					nsfw: { type: "boolean", description: "Mark channel as age-restricted." },
+					user_limit: {
+						type: "number",
+						description: "Max users in a voice channel (0–99, where 0 means unlimited). Voice channels only.",
+					},
+					bitrate: {
+						type: "number",
+						description: "Voice channel bitrate in bits per second (8000–96000 default; up to 384000 with server boosts). Voice channels only.",
+					},
+				},
+				required: ["channel_id"],
 			},
 		},
 	},
@@ -348,6 +380,64 @@ async function executeRenameChannel(guild: Guild, args: Record<string, unknown>)
 	};
 }
 
+async function executeUpdateChannel(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = UpdateChannelArgsSchema.parse(args);
+	const channel = guild.channels.cache.get(parsed.channel_id) as GuildChannel | undefined;
+
+	if (!channel) {
+		return {
+			toolCallId: "",
+			functionName: "update_channel",
+			success: false,
+			message: `Channel ${parsed.channel_id} not found`,
+		};
+	}
+
+	// Build edit payload — discord.js validates per-channel-type and rejects
+	// fields that don't apply (e.g. bitrate on a text channel) so we let it.
+	type EditPayload = {
+		topic?: string | null;
+		rateLimitPerUser?: number;
+		nsfw?: boolean;
+		userLimit?: number;
+		bitrate?: number;
+	};
+	const edit: EditPayload = {};
+	const changedFields: string[] = [];
+
+	if (parsed.topic !== undefined) {
+		edit.topic = parsed.topic;
+		changedFields.push(`topic=${parsed.topic === null ? "(cleared)" : `"${parsed.topic.slice(0, 60)}${parsed.topic.length > 60 ? "…" : ""}"`}`);
+	}
+	if (parsed.slowmode_seconds !== undefined) {
+		edit.rateLimitPerUser = parsed.slowmode_seconds;
+		changedFields.push(`slowmode=${parsed.slowmode_seconds}s`);
+	}
+	if (parsed.nsfw !== undefined) {
+		edit.nsfw = parsed.nsfw;
+		changedFields.push(`nsfw=${parsed.nsfw}`);
+	}
+	if (parsed.user_limit !== undefined) {
+		edit.userLimit = parsed.user_limit;
+		changedFields.push(`user_limit=${parsed.user_limit}`);
+	}
+	if (parsed.bitrate !== undefined) {
+		edit.bitrate = parsed.bitrate;
+		changedFields.push(`bitrate=${parsed.bitrate}`);
+	}
+
+	// Type-safe call — discord.js GuildChannel.edit accepts a union; cast via
+	// a narrow record so we don't import the full GuildChannelEditOptions type.
+	await (channel as GuildChannel & { edit: (options: EditPayload) => Promise<unknown> }).edit(edit);
+
+	return {
+		toolCallId: "",
+		functionName: "update_channel",
+		success: true,
+		message: `Updated "${channel.name}": ${changedFields.join(", ")}`,
+	};
+}
+
 async function executeCloneChannel(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
 	const parsed = CloneChannelArgsSchema.parse(args);
 	const source = guild.channels.cache.get(parsed.source_channel_id);
@@ -573,6 +663,7 @@ async function executeRemoveRole(guild: Guild, args: Record<string, unknown>): P
 export async function executeToolCall(guild: Guild, functionName: string, args: Record<string, unknown>): Promise<ActionResult> {
 	const executors: Record<string, (guild: Guild, args: Record<string, unknown>) => Promise<ActionResult>> = {
 		create_channel: executeCreateChannel,
+		update_channel: executeUpdateChannel,
 		set_channel_permission: executeSetChannelPermission,
 		move_channel: executeMoveChannel,
 		rename_channel: executeRenameChannel,
@@ -648,6 +739,25 @@ export function generateActionSummary(functionName: string, args: Record<string,
 			const a = args as { source_channel_id: string; new_name: string; position?: number };
 			const posStr = a.position !== undefined ? ` at position ${a.position}` : "";
 			return `Clone ${resolveChannelName(a.source_channel_id)} as "${a.new_name}"${posStr}`;
+		}
+		case "update_channel": {
+			const a = args as {
+				channel_id: string;
+				topic?: string | null;
+				slowmode_seconds?: number;
+				nsfw?: boolean;
+				user_limit?: number;
+				bitrate?: number;
+			};
+			const parts: string[] = [];
+			if (a.topic !== undefined) {
+				parts.push(`topic=${a.topic === null ? "(cleared)" : `"${a.topic.slice(0, 60)}${a.topic.length > 60 ? "…" : ""}"`}`);
+			}
+			if (a.slowmode_seconds !== undefined) parts.push(`slowmode=${a.slowmode_seconds}s`);
+			if (a.nsfw !== undefined) parts.push(`nsfw=${a.nsfw}`);
+			if (a.user_limit !== undefined) parts.push(`user_limit=${a.user_limit}`);
+			if (a.bitrate !== undefined) parts.push(`bitrate=${a.bitrate}`);
+			return `Update ${resolveChannelName(a.channel_id)}: ${parts.join(", ")}`;
 		}
 		case "delete_channel": {
 			const a = args as { channel_id: string };

--- a/src/services/adminAI/types.ts
+++ b/src/services/adminAI/types.ts
@@ -100,8 +100,12 @@ export const QueryAuditLogArgsSchema = z.object({
 export const UpdateChannelArgsSchema = z
 	.object({
 		channel_id: z.string(),
-		// Text/announcement/forum: channel "topic" / description (max 1024 chars per Discord)
-		topic: z.string().max(1024).nullable().optional(),
+		// Channel "topic" / description. Discord caps this at 1024 chars on
+		// text/announcement channels but allows up to 4096 chars on forum and
+		// media channels (their long-form post guidelines). We use the wider
+		// limit here so legitimate forum-guideline updates aren't rejected
+		// client-side; Discord enforces the per-type cap server-side anyway.
+		topic: z.string().max(4096).nullable().optional(),
 		// Slowmode in seconds. Discord allows 0–21600 (6 hours). 0 disables.
 		slowmode_seconds: z.number().int().min(0).max(21600).optional(),
 		nsfw: z.boolean().optional(),

--- a/src/services/adminAI/types.ts
+++ b/src/services/adminAI/types.ts
@@ -97,6 +97,31 @@ export const QueryAuditLogArgsSchema = z.object({
 	user_id: z.string().optional(),
 });
 
+export const UpdateChannelArgsSchema = z
+	.object({
+		channel_id: z.string(),
+		// Text/announcement/forum: channel "topic" / description (max 1024 chars per Discord)
+		topic: z.string().max(1024).nullable().optional(),
+		// Slowmode in seconds. Discord allows 0–21600 (6 hours). 0 disables.
+		slowmode_seconds: z.number().int().min(0).max(21600).optional(),
+		nsfw: z.boolean().optional(),
+		// Voice channels only
+		user_limit: z.number().int().min(0).max(99).optional(),
+		// Voice channels only — bits per second (8000–96000 stage; 8000–384000 boosted)
+		bitrate: z.number().int().min(8000).max(384000).optional(),
+	})
+	.refine(
+		(v) =>
+			v.topic !== undefined ||
+			v.slowmode_seconds !== undefined ||
+			v.nsfw !== undefined ||
+			v.user_limit !== undefined ||
+			v.bitrate !== undefined,
+		{ message: "At least one update field must be provided" },
+	);
+
+export type UpdateChannelArgs = z.infer<typeof UpdateChannelArgsSchema>;
+
 export type QueryAuditLogArgs = z.infer<typeof QueryAuditLogArgsSchema>;
 
 export interface PlannedAction {


### PR DESCRIPTION
## Summary

New action tool: \`update_channel\`. Lets the admin AI change a channel's settings without renaming or recreating it.

Triggered by asks like:
- *"set #general slowmode to 5 minutes"*
- *"update #voice-room description to 'AFK only'"*
- *"mark #spoilers NSFW"*
- *"raise #vc-1 user limit to 10"*

## Fields

Pass only what you want to change — the rest are left alone.

| Field | Applies to | Range |
|-------|------------|-------|
| \`topic\` | text / announcement / forum | string up to 1024 chars, or \`null\` to clear |
| \`slowmode_seconds\` | text | 0–21600 (Discord's 6-hour cap; 0 disables) |
| \`nsfw\` | any | boolean |
| \`user_limit\` | voice | 0–99 (0 = unlimited) |
| \`bitrate\` | voice | 8000–384000 bps |

Zod schema requires at least one update field — empty calls fail fast. Per-field bounds match Discord API limits so invalid inputs reject before hitting discord.js.

## Prompt guidance added

- Slowmode is in **seconds** (admin says "5 minutes" → pass 300).
- Bitrate is in **bits per second** (admin says "64 kbps" → pass 64000).
- Voice-only fields require confirming the target is a voice channel first.

## Test plan

- [x] \`bunx tsgo --noEmit\` clean
- [x] \`bun test src/services/adminAI/\` 112/112 pass
- [x] \`bunx oxlint --type-aware src/services/adminAI/\` 0 errors / 0 warnings
- [ ] Smoke test in Discord: ask bot to change a text channel's topic and slowmode
- [ ] Smoke test: ask bot to change a voice channel's user limit
- [ ] Smoke test: ask bot to clear a topic (\`topic: null\` path)

## Note

Built on \`origin/main\` so the broken-model-slug from #246 is still present here. Recommend merging #246 first; otherwise this PR also works once it lands behind it.