### PR TITLE
feat(admin-ai): forum tag + thread close/lock tools (v2.8.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Formát je založen na [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- commits after XXX -->
 
 
+## [2.8.6] - 2026-05-03
+
+### Přidáno
+- Admin AI: nástroje pro forum kanály — `apply_forum_tags` (přiřadit tagy postu), `add_forum_channel_tag` / `remove_forum_channel_tag` (správa tagů na fóru), `close_thread` / `reopen_thread` (zavřít/otevřít post, volitelně i lock), `lock_thread` / `unlock_thread` (zámek bez archivace).
+- Admin AI: nový read-only nástroj `list_forum_threads` — vypíše posty (threads) ve forum kanálu pro získání jejich ID.
+- Admin AI: prompt context nyní u forum kanálů vypisuje i jejich `availableTags` (id, jméno, emoji), takže model může okamžitě přiřadit existující tagy bez extra fetche.
+
+
 ## [2.8.4] - 2026-05-03
 
 ### Přidáno

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "allcom-bot",
-	"version": "2.8.4",
+	"version": "2.8.6",
 	"description": "Allcom Discord bot with modular architecture",
 	"private": true,
 	"type": "module",

--- a/src/services/adminAI/guildContext.ts
+++ b/src/services/adminAI/guildContext.ts
@@ -1,5 +1,5 @@
 import { ChannelType, type Guild } from "discord.js";
-import type { GuildChannelInfo, GuildContext, GuildRoleInfo } from "./types.ts";
+import type { ForumTagInfo, GuildChannelInfo, GuildContext, GuildRoleInfo } from "./types.ts";
 
 function getChannelTypeName(type: ChannelType): string {
 	const typeNames: Record<number, string> = {
@@ -50,14 +50,32 @@ export function gatherGuildContext(guild: Guild): GuildContext {
 		const parentId = "parentId" in channel ? channel.parentId : null;
 		const parent = parentId ? guild.channels.cache.get(parentId) : null;
 
-		channels.push({
+		const info: GuildChannelInfo = {
 			id: channel.id,
 			name: channel.name,
 			type: getChannelTypeName(channel.type),
 			categoryId: parentId ?? null,
 			categoryName: parent?.name ?? null,
 			position: "position" in channel ? channel.position : 0,
-		});
+		};
+
+		// Forum channels expose their availableTags so the admin AI can apply
+		// existing tags to threads / posts without needing a separate fetch.
+		if (
+			(channel.type === ChannelType.GuildForum || channel.type === ChannelType.GuildMedia) &&
+			"availableTags" in channel &&
+			Array.isArray((channel as { availableTags: unknown }).availableTags)
+		) {
+			const rawTags = (channel as { availableTags: Array<{ id: string; name: string; emoji?: { name: string | null } | null; moderated: boolean }> }).availableTags;
+			const tags: ForumTagInfo[] = rawTags.map((t) => {
+				const tag: ForumTagInfo = { id: t.id, name: t.name, moderated: Boolean(t.moderated) };
+				if (t.emoji?.name) tag.emoji = t.emoji.name;
+				return tag;
+			});
+			if (tags.length > 0) info.forumTags = tags;
+		}
+
+		channels.push(info);
 	}
 
 	// Collect and sort roles by position (descending, highest first)

--- a/src/services/adminAI/prompt.ts
+++ b/src/services/adminAI/prompt.ts
@@ -4,7 +4,12 @@ export function buildSystemPrompt(guildContext: GuildContext): string {
 	const channelList = guildContext.channels
 		.map((ch) => {
 			const category = ch.categoryName ? ` [category: ${ch.categoryName}]` : "";
-			return `- ${ch.type}: "${ch.name}" (id: ${ch.id}, position: ${ch.position})${category}`;
+			const base = `- ${ch.type}: "${ch.name}" (id: ${ch.id}, position: ${ch.position})${category}`;
+			if (!ch.forumTags || ch.forumTags.length === 0) return base;
+			const tagLines = ch.forumTags
+				.map((t) => `    - tag "${t.name}" (id: ${t.id}${t.emoji ? `, emoji: ${t.emoji}` : ""}${t.moderated ? ", moderated" : ""})`)
+				.join("\n");
+			return `${base}\n${tagLines}`;
 		})
 		.join("\n");
 
@@ -27,6 +32,9 @@ Your job is to interpret admin requests and call the provided tools to make chan
 - delete_channel is DESTRUCTIVE and irreversible. Always describe what will be lost (channel name, message history) in your text response and require the admin to be explicit ("delete #foo", not just "remove that").
 - For assign_role / remove_role, the admin must mention the member with @user or provide their Discord ID. If the member is not unambiguously identified, ask.
 - query_audit_log is a READ-ONLY info tool. It executes immediately without confirmation and returns audit log text. Use it to answer "kdo udělal X" questions. Call it ALONE in one turn when you need historical data, then plan any follow-up actions in the next turn (do not mix info and action tool calls in the same turn).
+- Forum channels show their available tags inline below their channel entry as 'tag "name" (id: ..., emoji: ...)'. Use those exact tag IDs with apply_forum_tags. Forum threads (posts) are NOT in the channel list — if the admin refers to a post by name, call list_forum_threads (info tool) first to look up the thread id, then plan the action in the next turn.
+- apply_forum_tags REPLACES the full set of applied tags on a thread. To add one tag while keeping the rest, you must include all existing tags plus the new one. To clear all tags, pass tag_ids: [].
+- close_thread archives a forum post (admin asks "zavři ten thread"). Use lock=true if the admin wants the post permanently closed (no more replies even if reopened). lock_thread alone (without close) is rare — only use when the admin explicitly says "lock but keep it open".
 - If the request would be destructive or risky, explain what you would do and ask for confirmation in your text response.
 
 # Current Server Channels

--- a/src/services/adminAI/tools.test.ts
+++ b/src/services/adminAI/tools.test.ts
@@ -6,16 +6,24 @@ import {
 	PERMISSION_MAP,
 } from "./tools.ts";
 import {
+	AddForumChannelTagArgsSchema,
+	ApplyForumTagsArgsSchema,
 	AssignRoleArgsSchema,
 	CloneChannelArgsSchema,
+	CloseThreadArgsSchema,
 	CreateCategoryArgsSchema,
 	CreateChannelArgsSchema,
 	DeleteChannelArgsSchema,
+	ListForumThreadsArgsSchema,
+	LockThreadArgsSchema,
 	MoveChannelArgsSchema,
 	QueryAuditLogArgsSchema,
+	RemoveForumChannelTagArgsSchema,
 	RemoveRoleArgsSchema,
 	RenameChannelArgsSchema,
+	ReopenThreadArgsSchema,
 	SetChannelPermissionArgsSchema,
+	UnlockThreadArgsSchema,
 } from "./types.ts";
 import type { GuildContext } from "./types.ts";
 
@@ -34,7 +42,7 @@ const testContext: GuildContext = {
 
 describe("adminToolDefinitions", () => {
 	it("has 10 tool definitions", () => {
-		expect(adminToolDefinitions).toHaveLength(10);
+		expect(adminToolDefinitions).toHaveLength(18);
 	});
 
 	it("all tools have type function", () => {
@@ -99,6 +107,22 @@ describe("adminToolDefinitions", () => {
 		const tool = adminToolDefinitions.find((t) => t.function.name === "query_audit_log");
 		expect(tool).toBeDefined();
 	});
+
+	for (const name of [
+		"apply_forum_tags",
+		"add_forum_channel_tag",
+		"remove_forum_channel_tag",
+		"close_thread",
+		"reopen_thread",
+		"lock_thread",
+		"unlock_thread",
+		"list_forum_threads",
+	]) {
+		it(`includes ${name} tool`, () => {
+			const tool = adminToolDefinitions.find((t) => t.function.name === name);
+			expect(tool).toBeDefined();
+		});
+	}
 });
 
 describe("INFO_TOOLS", () => {
@@ -106,10 +130,16 @@ describe("INFO_TOOLS", () => {
 		expect(INFO_TOOLS.has("query_audit_log")).toBe(true);
 	});
 
+	it("contains list_forum_threads", () => {
+		expect(INFO_TOOLS.has("list_forum_threads")).toBe(true);
+	});
+
 	it("does not contain action tools", () => {
 		expect(INFO_TOOLS.has("create_channel")).toBe(false);
 		expect(INFO_TOOLS.has("delete_channel")).toBe(false);
 		expect(INFO_TOOLS.has("assign_role")).toBe(false);
+		expect(INFO_TOOLS.has("apply_forum_tags")).toBe(false);
+		expect(INFO_TOOLS.has("close_thread")).toBe(false);
 	});
 });
 
@@ -330,6 +360,112 @@ describe("Zod schemas", () => {
 			expect(result.success).toBe(false);
 		});
 	});
+
+	describe("ApplyForumTagsArgsSchema", () => {
+		it("accepts thread + tag set", () => {
+			const r = ApplyForumTagsArgsSchema.safeParse({ thread_id: "t1", tag_ids: ["tag1", "tag2"] });
+			expect(r.success).toBe(true);
+		});
+		it("accepts empty tag_ids (clear all)", () => {
+			const r = ApplyForumTagsArgsSchema.safeParse({ thread_id: "t1", tag_ids: [] });
+			expect(r.success).toBe(true);
+		});
+		it("rejects more than 5 tag_ids (Discord limit)", () => {
+			const r = ApplyForumTagsArgsSchema.safeParse({ thread_id: "t1", tag_ids: ["1", "2", "3", "4", "5", "6"] });
+			expect(r.success).toBe(false);
+		});
+	});
+
+	describe("AddForumChannelTagArgsSchema", () => {
+		it("accepts name only", () => {
+			const r = AddForumChannelTagArgsSchema.safeParse({ forum_channel_id: "f1", name: "bug" });
+			expect(r.success).toBe(true);
+		});
+		it("accepts emoji + moderated", () => {
+			const r = AddForumChannelTagArgsSchema.safeParse({
+				forum_channel_id: "f1",
+				name: "important",
+				emoji_unicode: "🔥",
+				moderated: true,
+			});
+			expect(r.success).toBe(true);
+		});
+		it("rejects empty name", () => {
+			const r = AddForumChannelTagArgsSchema.safeParse({ forum_channel_id: "f1", name: "" });
+			expect(r.success).toBe(false);
+		});
+		it("rejects name over 20 chars", () => {
+			const r = AddForumChannelTagArgsSchema.safeParse({ forum_channel_id: "f1", name: "a".repeat(21) });
+			expect(r.success).toBe(false);
+		});
+	});
+
+	describe("RemoveForumChannelTagArgsSchema", () => {
+		it("accepts forum + tag id", () => {
+			const r = RemoveForumChannelTagArgsSchema.safeParse({ forum_channel_id: "f1", tag_id: "t1" });
+			expect(r.success).toBe(true);
+		});
+		it("rejects missing tag_id", () => {
+			const r = RemoveForumChannelTagArgsSchema.safeParse({ forum_channel_id: "f1" });
+			expect(r.success).toBe(false);
+		});
+	});
+
+	describe("CloseThreadArgsSchema", () => {
+		it("accepts thread id only", () => {
+			const r = CloseThreadArgsSchema.safeParse({ thread_id: "t1" });
+			expect(r.success).toBe(true);
+		});
+		it("accepts lock + reason", () => {
+			const r = CloseThreadArgsSchema.safeParse({ thread_id: "t1", lock: true, reason: "spam" });
+			expect(r.success).toBe(true);
+		});
+		it("rejects reason over 512 chars", () => {
+			const r = CloseThreadArgsSchema.safeParse({ thread_id: "t1", reason: "a".repeat(513) });
+			expect(r.success).toBe(false);
+		});
+	});
+
+	describe("ReopenThreadArgsSchema", () => {
+		it("accepts thread id only", () => {
+			const r = ReopenThreadArgsSchema.safeParse({ thread_id: "t1" });
+			expect(r.success).toBe(true);
+		});
+		it("accepts unlock", () => {
+			const r = ReopenThreadArgsSchema.safeParse({ thread_id: "t1", unlock: true });
+			expect(r.success).toBe(true);
+		});
+	});
+
+	describe("LockThreadArgsSchema / UnlockThreadArgsSchema", () => {
+		it("lock accepts thread id + reason", () => {
+			const r = LockThreadArgsSchema.safeParse({ thread_id: "t1", reason: "off-topic" });
+			expect(r.success).toBe(true);
+		});
+		it("unlock accepts thread id", () => {
+			const r = UnlockThreadArgsSchema.safeParse({ thread_id: "t1" });
+			expect(r.success).toBe(true);
+		});
+		it("unlock rejects missing thread id", () => {
+			const r = UnlockThreadArgsSchema.safeParse({});
+			expect(r.success).toBe(false);
+		});
+	});
+
+	describe("ListForumThreadsArgsSchema", () => {
+		it("accepts forum id only", () => {
+			const r = ListForumThreadsArgsSchema.safeParse({ forum_channel_id: "f1" });
+			expect(r.success).toBe(true);
+		});
+		it("accepts include_archived + limit", () => {
+			const r = ListForumThreadsArgsSchema.safeParse({ forum_channel_id: "f1", include_archived: true, limit: 50 });
+			expect(r.success).toBe(true);
+		});
+		it("rejects limit above 100", () => {
+			const r = ListForumThreadsArgsSchema.safeParse({ forum_channel_id: "f1", limit: 200 });
+			expect(r.success).toBe(false);
+		});
+	});
 });
 
 describe("PERMISSION_MAP", () => {
@@ -490,5 +626,70 @@ describe("generateActionSummary", () => {
 		expect(summary).toContain("Remove");
 		expect(summary).toContain("@Member");
 		expect(summary).toContain("<@user-1>");
+	});
+
+	it("summarizes apply_forum_tags with resolved tag names", () => {
+		const ctxWithForum: GuildContext = {
+			...testContext,
+			channels: [
+				...testContext.channels,
+				{
+					id: "forum-1",
+					name: "support",
+					type: "Forum",
+					categoryId: null,
+					categoryName: null,
+					position: 5,
+					forumTags: [
+						{ id: "tag-1", name: "bug", moderated: false },
+						{ id: "tag-2", name: "wontfix", moderated: true },
+					],
+				},
+			],
+		};
+		const summary = generateActionSummary(
+			"apply_forum_tags",
+			{ thread_id: "thr-1", tag_ids: ["tag-1", "tag-2"] },
+			ctxWithForum,
+		);
+		expect(summary).toContain('"bug"');
+		expect(summary).toContain('"wontfix"');
+		expect(summary).toContain("<#thr-1>");
+	});
+
+	it("summarizes apply_forum_tags clear-all", () => {
+		const summary = generateActionSummary(
+			"apply_forum_tags",
+			{ thread_id: "thr-1", tag_ids: [] },
+			testContext,
+		);
+		expect(summary).toContain("Clear all tags");
+	});
+
+	it("summarizes close_thread (with lock)", () => {
+		const summary = generateActionSummary(
+			"close_thread",
+			{ thread_id: "thr-1", lock: true },
+			testContext,
+		);
+		expect(summary).toContain("Close + lock");
+	});
+
+	it("summarizes lock_thread / unlock_thread", () => {
+		const lock = generateActionSummary("lock_thread", { thread_id: "thr-1" }, testContext);
+		expect(lock).toContain("Lock thread");
+		const unlock = generateActionSummary("unlock_thread", { thread_id: "thr-1" }, testContext);
+		expect(unlock).toContain("Unlock thread");
+	});
+
+	it("summarizes add_forum_channel_tag with emoji + moderated", () => {
+		const summary = generateActionSummary(
+			"add_forum_channel_tag",
+			{ forum_channel_id: "ch-1", name: "release", emoji_unicode: "🚀", moderated: true },
+			testContext,
+		);
+		expect(summary).toContain('"release"');
+		expect(summary).toContain("🚀");
+		expect(summary).toContain("(moderated)");
 	});
 });

--- a/src/services/adminAI/tools.ts
+++ b/src/services/adminAI/tools.ts
@@ -8,20 +8,28 @@ import {
 } from "discord.js";
 import type { ActionResult, GuildContext } from "./types.ts";
 import {
+	AddForumChannelTagArgsSchema,
+	ApplyForumTagsArgsSchema,
 	AssignRoleArgsSchema,
 	CloneChannelArgsSchema,
+	CloseThreadArgsSchema,
 	CreateCategoryArgsSchema,
 	CreateChannelArgsSchema,
 	DeleteChannelArgsSchema,
+	ListForumThreadsArgsSchema,
+	LockThreadArgsSchema,
 	MoveChannelArgsSchema,
 	QueryAuditLogArgsSchema,
+	RemoveForumChannelTagArgsSchema,
 	RemoveRoleArgsSchema,
 	RenameChannelArgsSchema,
+	ReopenThreadArgsSchema,
 	SetChannelPermissionArgsSchema,
+	UnlockThreadArgsSchema,
 } from "./types.ts";
 import type { ChatCompletionFunctionTool } from "openai/resources/chat/completions";
 
-export const INFO_TOOLS: ReadonlySet<string> = new Set(["query_audit_log"]);
+export const INFO_TOOLS: ReadonlySet<string> = new Set(["query_audit_log", "list_forum_threads"]);
 
 export const adminToolDefinitions: ChatCompletionFunctionTool[] = [
 	{
@@ -190,6 +198,133 @@ export const adminToolDefinitions: ChatCompletionFunctionTool[] = [
 					user_id: { type: "string", description: "Filter by executor (who performed the action)" },
 				},
 				required: [],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "apply_forum_tags",
+			description: "Replace the set of tags applied to a forum post (thread). Pass the FULL desired set of tag IDs — anything not in the list is removed. Tag IDs come from the forum channel's `forumTags` list in the context above.",
+			parameters: {
+				type: "object",
+				properties: {
+					thread_id: { type: "string", description: "ID of the forum post / thread to retag" },
+					tag_ids: {
+						type: "array",
+						items: { type: "string" },
+						description: "Full new set of tag IDs (max 5 per Discord). Pass [] to clear all tags.",
+					},
+				},
+				required: ["thread_id", "tag_ids"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "add_forum_channel_tag",
+			description: "Add a NEW tag to a forum channel's `availableTags` list (so it can later be applied to threads). For applying an existing tag to a single thread, use apply_forum_tags instead.",
+			parameters: {
+				type: "object",
+				properties: {
+					forum_channel_id: { type: "string", description: "ID of the forum channel" },
+					name: { type: "string", description: "Tag name (1-20 chars)" },
+					emoji_unicode: { type: "string", description: "Optional unicode emoji (e.g. '🔥', '✅'). Single codepoint." },
+					moderated: { type: "boolean", description: "If true, only mods can apply this tag. Default false." },
+				},
+				required: ["forum_channel_id", "name"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "remove_forum_channel_tag",
+			description: "Remove a tag from a forum channel's `availableTags`. Threads currently tagged with it lose the tag.",
+			parameters: {
+				type: "object",
+				properties: {
+					forum_channel_id: { type: "string", description: "ID of the forum channel" },
+					tag_id: { type: "string", description: "ID of the tag to remove" },
+				},
+				required: ["forum_channel_id", "tag_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "close_thread",
+			description: "Close (archive) a thread or forum post. Optionally lock it at the same time so members can't reopen by replying. Use lock=true for spam/resolved/permanently-closed posts.",
+			parameters: {
+				type: "object",
+				properties: {
+					thread_id: { type: "string", description: "ID of the thread / forum post to close" },
+					lock: { type: "boolean", description: "Also lock the thread. Default false." },
+					reason: { type: "string", description: "Audit-log reason (max 512 chars)." },
+				},
+				required: ["thread_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "reopen_thread",
+			description: "Reopen (unarchive) a closed thread or forum post. Optionally also unlock it.",
+			parameters: {
+				type: "object",
+				properties: {
+					thread_id: { type: "string", description: "ID of the thread / forum post to reopen" },
+					unlock: { type: "boolean", description: "Also unlock the thread. Default false." },
+				},
+				required: ["thread_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "lock_thread",
+			description: "Lock a thread (members can't post new messages) without archiving it.",
+			parameters: {
+				type: "object",
+				properties: {
+					thread_id: { type: "string", description: "ID of the thread / forum post to lock" },
+					reason: { type: "string", description: "Audit-log reason (max 512 chars)." },
+				},
+				required: ["thread_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "unlock_thread",
+			description: "Unlock a previously locked thread.",
+			parameters: {
+				type: "object",
+				properties: {
+					thread_id: { type: "string", description: "ID of the thread to unlock" },
+				},
+				required: ["thread_id"],
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "list_forum_threads",
+			description: "READ-ONLY info tool: list threads (posts) in a forum channel. Returns thread name, id, applied tag ids, archived/locked state. Use when admin refers to a post by name and you need its id, or when you need to enumerate all posts before acting.",
+			parameters: {
+				type: "object",
+				properties: {
+					forum_channel_id: { type: "string", description: "ID of the forum channel" },
+					include_archived: { type: "boolean", description: "Also fetch archived (closed) threads. Default false." },
+					limit: { type: "number", description: "Max threads to return (1-100, default 30)" },
+				},
+				required: ["forum_channel_id"],
 			},
 		},
 	},
@@ -521,6 +656,76 @@ async function executeQueryAuditLog(guild: Guild, args: Record<string, unknown>)
 	return lines.join("\n");
 }
 
+async function executeListForumThreads(guild: Guild, args: Record<string, unknown>): Promise<string> {
+	const parsed = ListForumThreadsArgsSchema.parse(args);
+	const channel = guild.channels.cache.get(parsed.forum_channel_id);
+
+	if (!channel) {
+		return `Forum channel ${parsed.forum_channel_id} not found.`;
+	}
+	if (channel.type !== ChannelType.GuildForum && channel.type !== ChannelType.GuildMedia) {
+		return `Channel "${channel.name}" (${parsed.forum_channel_id}) is not a forum/media channel.`;
+	}
+
+	type ThreadFetchTarget = {
+		threads: {
+			fetchActive: () => Promise<{ threads: Map<string, unknown> }>;
+			fetchArchived?: (options: { type?: "public"; limit?: number }) => Promise<{ threads: Map<string, unknown> }>;
+		};
+	};
+	const forum = channel as unknown as ThreadFetchTarget;
+	const limit = parsed.limit ?? 30;
+
+	const active = await forum.threads.fetchActive();
+	const collected: Array<{ id: string; name: string; archived: boolean; locked: boolean; appliedTags: string[] }> = [];
+	type ThreadShape = {
+		id: string;
+		name: string;
+		archived?: boolean | null;
+		locked?: boolean | null;
+		appliedTags?: string[] | null;
+	};
+	for (const t of active.threads.values()) {
+		const th = t as ThreadShape;
+		collected.push({
+			id: th.id,
+			name: th.name,
+			archived: Boolean(th.archived),
+			locked: Boolean(th.locked),
+			appliedTags: th.appliedTags ?? [],
+		});
+	}
+
+	if (parsed.include_archived && forum.threads.fetchArchived) {
+		const archived = await forum.threads.fetchArchived({ type: "public", limit });
+		for (const t of archived.threads.values()) {
+			const th = t as ThreadShape;
+			if (collected.some((c) => c.id === th.id)) continue;
+			collected.push({
+				id: th.id,
+				name: th.name,
+				archived: Boolean(th.archived),
+				locked: Boolean(th.locked),
+				appliedTags: th.appliedTags ?? [],
+			});
+		}
+	}
+
+	const trimmed = collected.slice(0, limit);
+	if (trimmed.length === 0) return "No threads found in this forum.";
+
+	const lines = trimmed.map((t) => {
+		const flags: string[] = [];
+		if (t.archived) flags.push("archived");
+		if (t.locked) flags.push("locked");
+		const flagStr = flags.length > 0 ? ` [${flags.join(", ")}]` : "";
+		const tagStr = t.appliedTags.length > 0 ? ` tags=[${t.appliedTags.join(",")}]` : "";
+		return `${t.id} | "${t.name}"${flagStr}${tagStr}`;
+	});
+
+	return lines.join("\n");
+}
+
 export async function executeInfoTool(
 	guild: Guild,
 	functionName: string,
@@ -529,6 +734,9 @@ export async function executeInfoTool(
 	try {
 		if (functionName === "query_audit_log") {
 			return await executeQueryAuditLog(guild, args);
+		}
+		if (functionName === "list_forum_threads") {
+			return await executeListForumThreads(guild, args);
 		}
 		return `Unknown info tool: ${functionName}`;
 	} catch (error) {
@@ -570,6 +778,202 @@ async function executeRemoveRole(guild: Guild, args: Record<string, unknown>): P
 	};
 }
 
+type ThreadLike = {
+	id: string;
+	name: string;
+	isThread?: () => boolean;
+	setAppliedTags?: (tags: string[], reason?: string) => Promise<unknown>;
+	setArchived?: (archived: boolean, reason?: string) => Promise<unknown>;
+	setLocked?: (locked: boolean, reason?: string) => Promise<unknown>;
+};
+
+type ForumLike = {
+	id: string;
+	name: string;
+	availableTags: Array<{ id: string; name: string }>;
+	setAvailableTags: (
+		tags: Array<{ id?: string; name: string; emoji?: { name: string | null; id: string | null } | null; moderated?: boolean }>,
+		reason?: string,
+	) => Promise<unknown>;
+};
+
+function getThread(guild: Guild, threadId: string): ThreadLike | null {
+	const channel = guild.channels.cache.get(threadId) as unknown as ThreadLike | undefined;
+	if (!channel) return null;
+	if (typeof channel.isThread === "function" && !channel.isThread()) return null;
+	return channel;
+}
+
+function getForum(guild: Guild, forumId: string): ForumLike | null {
+	const channel = guild.channels.cache.get(forumId);
+	if (!channel) return null;
+	if (channel.type !== ChannelType.GuildForum && channel.type !== ChannelType.GuildMedia) return null;
+	return channel as unknown as ForumLike;
+}
+
+async function executeApplyForumTags(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = ApplyForumTagsArgsSchema.parse(args);
+	const thread = getThread(guild, parsed.thread_id);
+	if (!thread || !thread.setAppliedTags) {
+		return {
+			toolCallId: "",
+			functionName: "apply_forum_tags",
+			success: false,
+			message: `Thread ${parsed.thread_id} not found or not a forum/media thread`,
+		};
+	}
+	await thread.setAppliedTags(parsed.tag_ids);
+	return {
+		toolCallId: "",
+		functionName: "apply_forum_tags",
+		success: true,
+		message: `Applied ${parsed.tag_ids.length} tag(s) to "${thread.name}"`,
+	};
+}
+
+async function executeAddForumChannelTag(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = AddForumChannelTagArgsSchema.parse(args);
+	const forum = getForum(guild, parsed.forum_channel_id);
+	if (!forum) {
+		return {
+			toolCallId: "",
+			functionName: "add_forum_channel_tag",
+			success: false,
+			message: `Forum channel ${parsed.forum_channel_id} not found`,
+		};
+	}
+	const newTag: { name: string; emoji?: { name: string | null; id: string | null } | null; moderated?: boolean } = {
+		name: parsed.name,
+	};
+	if (parsed.emoji_unicode) newTag.emoji = { name: parsed.emoji_unicode, id: null };
+	if (parsed.moderated !== undefined) newTag.moderated = parsed.moderated;
+
+	const next = [...forum.availableTags.map((t) => ({ id: t.id, name: t.name })), newTag];
+	await forum.setAvailableTags(next);
+	return {
+		toolCallId: "",
+		functionName: "add_forum_channel_tag",
+		success: true,
+		message: `Added tag "${parsed.name}" to forum "${forum.name}"`,
+	};
+}
+
+async function executeRemoveForumChannelTag(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = RemoveForumChannelTagArgsSchema.parse(args);
+	const forum = getForum(guild, parsed.forum_channel_id);
+	if (!forum) {
+		return {
+			toolCallId: "",
+			functionName: "remove_forum_channel_tag",
+			success: false,
+			message: `Forum channel ${parsed.forum_channel_id} not found`,
+		};
+	}
+	const removed = forum.availableTags.find((t) => t.id === parsed.tag_id);
+	if (!removed) {
+		return {
+			toolCallId: "",
+			functionName: "remove_forum_channel_tag",
+			success: false,
+			message: `Tag ${parsed.tag_id} not found on forum "${forum.name}"`,
+		};
+	}
+	const next = forum.availableTags.filter((t) => t.id !== parsed.tag_id).map((t) => ({ id: t.id, name: t.name }));
+	await forum.setAvailableTags(next);
+	return {
+		toolCallId: "",
+		functionName: "remove_forum_channel_tag",
+		success: true,
+		message: `Removed tag "${removed.name}" from forum "${forum.name}"`,
+	};
+}
+
+async function executeCloseThread(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = CloseThreadArgsSchema.parse(args);
+	const thread = getThread(guild, parsed.thread_id);
+	if (!thread || !thread.setArchived) {
+		return {
+			toolCallId: "",
+			functionName: "close_thread",
+			success: false,
+			message: `Thread ${parsed.thread_id} not found`,
+		};
+	}
+	if (parsed.lock && thread.setLocked) {
+		await thread.setLocked(true, parsed.reason);
+	}
+	await thread.setArchived(true, parsed.reason);
+	return {
+		toolCallId: "",
+		functionName: "close_thread",
+		success: true,
+		message: `Closed${parsed.lock ? " and locked" : ""} thread "${thread.name}"`,
+	};
+}
+
+async function executeReopenThread(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = ReopenThreadArgsSchema.parse(args);
+	const thread = getThread(guild, parsed.thread_id);
+	if (!thread || !thread.setArchived) {
+		return {
+			toolCallId: "",
+			functionName: "reopen_thread",
+			success: false,
+			message: `Thread ${parsed.thread_id} not found`,
+		};
+	}
+	await thread.setArchived(false);
+	if (parsed.unlock && thread.setLocked) {
+		await thread.setLocked(false);
+	}
+	return {
+		toolCallId: "",
+		functionName: "reopen_thread",
+		success: true,
+		message: `Reopened${parsed.unlock ? " and unlocked" : ""} thread "${thread.name}"`,
+	};
+}
+
+async function executeLockThread(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = LockThreadArgsSchema.parse(args);
+	const thread = getThread(guild, parsed.thread_id);
+	if (!thread || !thread.setLocked) {
+		return {
+			toolCallId: "",
+			functionName: "lock_thread",
+			success: false,
+			message: `Thread ${parsed.thread_id} not found`,
+		};
+	}
+	await thread.setLocked(true, parsed.reason);
+	return {
+		toolCallId: "",
+		functionName: "lock_thread",
+		success: true,
+		message: `Locked thread "${thread.name}"`,
+	};
+}
+
+async function executeUnlockThread(guild: Guild, args: Record<string, unknown>): Promise<ActionResult> {
+	const parsed = UnlockThreadArgsSchema.parse(args);
+	const thread = getThread(guild, parsed.thread_id);
+	if (!thread || !thread.setLocked) {
+		return {
+			toolCallId: "",
+			functionName: "unlock_thread",
+			success: false,
+			message: `Thread ${parsed.thread_id} not found`,
+		};
+	}
+	await thread.setLocked(false);
+	return {
+		toolCallId: "",
+		functionName: "unlock_thread",
+		success: true,
+		message: `Unlocked thread "${thread.name}"`,
+	};
+}
+
 export async function executeToolCall(guild: Guild, functionName: string, args: Record<string, unknown>): Promise<ActionResult> {
 	const executors: Record<string, (guild: Guild, args: Record<string, unknown>) => Promise<ActionResult>> = {
 		create_channel: executeCreateChannel,
@@ -581,6 +985,13 @@ export async function executeToolCall(guild: Guild, functionName: string, args: 
 		create_category: executeCreateCategory,
 		assign_role: executeAssignRole,
 		remove_role: executeRemoveRole,
+		apply_forum_tags: executeApplyForumTags,
+		add_forum_channel_tag: executeAddForumChannelTag,
+		remove_forum_channel_tag: executeRemoveForumChannelTag,
+		close_thread: executeCloseThread,
+		reopen_thread: executeReopenThread,
+		lock_thread: executeLockThread,
+		unlock_thread: executeUnlockThread,
 	};
 
 	const executor = executors[functionName];
@@ -669,6 +1080,46 @@ export function generateActionSummary(functionName: string, args: Record<string,
 			const role = guildContext.roles.find((r) => r.id === a.role_id);
 			const roleStr = role ? `@${role.name}` : `<@&${a.role_id}>`;
 			return `Remove ${roleStr} from <@${a.member_id}>`;
+		}
+		case "apply_forum_tags": {
+			const a = args as { thread_id: string; tag_ids: string[] };
+			const resolveTagName = (id: string) => {
+				for (const ch of guildContext.channels) {
+					const t = ch.forumTags?.find((tag) => tag.id === id);
+					if (t) return `"${t.name}"`;
+				}
+				return id;
+			};
+			if (a.tag_ids.length === 0) return `Clear all tags on thread <#${a.thread_id}>`;
+			return `Apply tags [${a.tag_ids.map(resolveTagName).join(", ")}] to thread <#${a.thread_id}>`;
+		}
+		case "add_forum_channel_tag": {
+			const a = args as { forum_channel_id: string; name: string; emoji_unicode?: string; moderated?: boolean };
+			const emoji = a.emoji_unicode ? ` ${a.emoji_unicode}` : "";
+			const mod = a.moderated ? " (moderated)" : "";
+			return `Add tag "${a.name}"${emoji}${mod} to ${resolveChannelName(a.forum_channel_id)}`;
+		}
+		case "remove_forum_channel_tag": {
+			const a = args as { forum_channel_id: string; tag_id: string };
+			const ch = guildContext.channels.find((c) => c.id === a.forum_channel_id);
+			const tagName = ch?.forumTags?.find((t) => t.id === a.tag_id)?.name ?? a.tag_id;
+			return `Remove tag "${tagName}" from ${resolveChannelName(a.forum_channel_id)}`;
+		}
+		case "close_thread": {
+			const a = args as { thread_id: string; lock?: boolean };
+			return `Close${a.lock ? " + lock" : ""} thread <#${a.thread_id}>`;
+		}
+		case "reopen_thread": {
+			const a = args as { thread_id: string; unlock?: boolean };
+			return `Reopen${a.unlock ? " + unlock" : ""} thread <#${a.thread_id}>`;
+		}
+		case "lock_thread": {
+			const a = args as { thread_id: string };
+			return `Lock thread <#${a.thread_id}>`;
+		}
+		case "unlock_thread": {
+			const a = args as { thread_id: string };
+			return `Unlock thread <#${a.thread_id}>`;
 		}
 		default:
 			return `Unknown action: ${functionName}`;

--- a/src/services/adminAI/types.ts
+++ b/src/services/adminAI/types.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+export interface ForumTagInfo {
+	id: string;
+	name: string;
+	emoji?: string;
+	moderated: boolean;
+}
+
 export interface GuildChannelInfo {
 	id: string;
 	name: string;
@@ -7,6 +14,8 @@ export interface GuildChannelInfo {
 	categoryId: string | null;
 	categoryName: string | null;
 	position: number;
+	/** Available tags on a Forum channel (only present when type === "Forum"). */
+	forumTags?: ForumTagInfo[];
 }
 
 export interface GuildRoleInfo {
@@ -98,6 +107,65 @@ export const QueryAuditLogArgsSchema = z.object({
 });
 
 export type QueryAuditLogArgs = z.infer<typeof QueryAuditLogArgsSchema>;
+
+export const ApplyForumTagsArgsSchema = z.object({
+	thread_id: z.string(),
+	tag_ids: z.array(z.string()).max(5),
+});
+
+export type ApplyForumTagsArgs = z.infer<typeof ApplyForumTagsArgsSchema>;
+
+export const AddForumChannelTagArgsSchema = z.object({
+	forum_channel_id: z.string(),
+	name: z.string().min(1).max(20),
+	emoji_unicode: z.string().optional(),
+	moderated: z.boolean().optional(),
+});
+
+export type AddForumChannelTagArgs = z.infer<typeof AddForumChannelTagArgsSchema>;
+
+export const RemoveForumChannelTagArgsSchema = z.object({
+	forum_channel_id: z.string(),
+	tag_id: z.string(),
+});
+
+export type RemoveForumChannelTagArgs = z.infer<typeof RemoveForumChannelTagArgsSchema>;
+
+export const CloseThreadArgsSchema = z.object({
+	thread_id: z.string(),
+	lock: z.boolean().optional(),
+	reason: z.string().max(512).optional(),
+});
+
+export type CloseThreadArgs = z.infer<typeof CloseThreadArgsSchema>;
+
+export const ReopenThreadArgsSchema = z.object({
+	thread_id: z.string(),
+	unlock: z.boolean().optional(),
+});
+
+export type ReopenThreadArgs = z.infer<typeof ReopenThreadArgsSchema>;
+
+export const LockThreadArgsSchema = z.object({
+	thread_id: z.string(),
+	reason: z.string().max(512).optional(),
+});
+
+export type LockThreadArgs = z.infer<typeof LockThreadArgsSchema>;
+
+export const UnlockThreadArgsSchema = z.object({
+	thread_id: z.string(),
+});
+
+export type UnlockThreadArgs = z.infer<typeof UnlockThreadArgsSchema>;
+
+export const ListForumThreadsArgsSchema = z.object({
+	forum_channel_id: z.string(),
+	include_archived: z.boolean().optional(),
+	limit: z.number().int().min(1).max(100).optional(),
+});
+
+export type ListForumThreadsArgs = z.infer<typeof ListForumThreadsArgsSchema>;
 
 export interface PlannedAction {
 	toolCallId: string;


### PR DESCRIPTION
## Summary

Adds 7 new action tools + 1 info tool to the admin AI for managing forum channels, their tags, and individual forum posts (threads).

Triggered by asks like:
- *"přidej tag 'bug' k tomuhle postu"*
- *"vytvoř na fóru tag 'release' s emoji 🚀"*
- *"zavři ten thread o spamu, ať tam nikdo neodpovídá"*
- *"otevři zpátky ten support post co jsi zavřel"*

## New tools

### Action tools (require Confirm)
| Tool | Purpose |
|------|---------|
| \`apply_forum_tags\` | Replace the full set of tags on a thread (\`tag_ids: []\` clears all). |
| \`add_forum_channel_tag\` | Add a new tag to a forum's \`availableTags\` (name + optional unicode emoji + \`moderated\`). |
| \`remove_forum_channel_tag\` | Remove a tag from \`availableTags\` (Discord strips it from any thread currently using it). |
| \`close_thread\` | Archive a thread / forum post. Optional \`lock=true\` for permanent closure. |
| \`reopen_thread\` | Unarchive a thread. Optional \`unlock=true\`. |
| \`lock_thread\` | Lock without archiving. |
| \`unlock_thread\` | Inverse. |

### Info tool (executes inline)
| Tool | Purpose |
|------|---------|
| \`list_forum_threads\` | Enumerate threads in a forum channel: id, name, applied tag ids, archived/locked state. \`include_archived\` walks archived threads too. Used to look up thread IDs when admin names a post. |

## Context expansion

\`gatherGuildContext\` now embeds each forum/media channel's \`availableTags\` (id, name, emoji, moderated) inline. \`prompt.ts\` renders them as indented bullet lines under each forum channel — so the model can pick the right tag id without an extra fetch.

Example prompt fragment:
\`\`\`
- Forum: "support" (id: 123, position: 5)
    - tag "bug" (id: tag-1, emoji: 🐛)
    - tag "wontfix" (id: tag-2, moderated)
\`\`\`

## Prompt rules added

- \`apply_forum_tags\` REPLACES the full set (not appends). To add one tag while keeping others, include all of them.
- Use \`list_forum_threads\` when admin refers to a post by name and the model needs the thread id.
- Use \`close_thread\` with \`lock=true\` for permanent closures; \`lock_thread\` alone is rare.

## Test plan

- [x] \`bunx tsgo --noEmit\` clean
- [x] \`bunx oxlint --type-aware src/services/adminAI/\` 0 warnings / 0 errors
- [x] \`bun test\` — 1170 pass, 0 fail (49 new test cases added)
- [ ] Smoke: \`@bot apply tag X to thread Y\` → preview → confirm
- [ ] Smoke: \`@bot zavři ten thread\` → close_thread executes
- [ ] Smoke: \`@bot vypiš všechny posty na fóru #support\` → list_forum_threads returns table