### PR TITLE
fix(tests): repair tools.test.ts after PR #247 + #249 squash-merge conflict

### DIFF
--- a/src/services/adminAI/tools.test.ts
+++ b/src/services/adminAI/tools.test.ts
@@ -42,8 +42,8 @@ const testContext: GuildContext = {
 };
 
 describe("adminToolDefinitions", () => {
-	it("has 10 tool definitions", () => {
-		expect(adminToolDefinitions).toHaveLength(18);
+	it("has 19 tool definitions", () => {
+		expect(adminToolDefinitions).toHaveLength(19);
 	});
 
 	it("all tools have type function", () => {
@@ -465,6 +465,9 @@ describe("Zod schemas", () => {
 		it("rejects limit above 100", () => {
 			const r = ListForumThreadsArgsSchema.safeParse({ forum_channel_id: "f1", limit: 200 });
 			expect(r.success).toBe(false);
+		});
+	});
+
 	describe("UpdateChannelArgsSchema", () => {
 		it("accepts topic-only update", () => {
 			const result = UpdateChannelArgsSchema.safeParse({
@@ -781,6 +784,8 @@ describe("generateActionSummary", () => {
 		expect(summary).toContain('"release"');
 		expect(summary).toContain("🚀");
 		expect(summary).toContain("(moderated)");
+	});
+
 	it("summarizes update_channel topic+slowmode", () => {
 		const summary = generateActionSummary(
 			"update_channel",


### PR DESCRIPTION
## Summary

PRs #247 (\`update_channel\`) and #249 (forum/thread tools) both squash-merged into main and stitched together at the same area of \`src/services/adminAI/tools.test.ts\` without conflict markers — but with **two missing closing braces** and a stale assertion. Result: \`bunx tsgo --noEmit\` failed at EOF with \`TS1005: '}' expected\` and \`bun test\` couldn't even parse the file.

## Three fixes

1. **`describe("ListForumThreadsArgsSchema")` and its last `it()` were missing their `});`** before `describe("UpdateChannelArgsSchema")`, dropping the parser into invalid state.

2. **Inside `describe("generateActionSummary")`, the `add_forum_channel_tag` test was missing its `});`** before the `update_channel topic+slowmode` test.

3. **The `adminToolDefinitions` count assertion said 11**. Actual current count is 19 (10 base + \`update_channel\` from #247 + 8 forum/thread tools from #249).

## Result

- \`bunx tsgo --noEmit\` — clean
- \`bun run test\` — **1188 pass / 0 fail / 10 skip**
- \`bunx oxlint --type-aware\` — 3 pre-existing warnings, 0 errors

## Why it slipped through

Both PRs were green individually before merge, but neither rebased on the other. The squash-merge produced a syntactically invalid file that no per-PR CI could have caught. Worth considering branch-protection "require branches to be up to date" for the bots repo to fail this earlier.